### PR TITLE
Replaced JSON with JSON::PP in modules

### DIFF
--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -107,7 +107,7 @@ sub create_new_test {
     $queue = $test_params->{queue} if (defined $test_params->{queue});
 
     $test_params->{domain} = $domain;
-    my $js                             = JSON->new->canonical;
+    my $js                             = JSON::PP->new->canonical;
     my $encoded_params                 = $js->encode( $test_params );
     my $test_params_deterministic_hash = md5_hex( $encoded_params );
     my $result_id;
@@ -271,7 +271,7 @@ sub add_batch_job {
     my $batch_id;
 
 	my $dbh = $self->dbh;
-	my $js = JSON->new;
+	my $js = JSON::PP->new;
 	$js->canonical( 1 );
     		
     if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -125,7 +125,7 @@ sub create_new_test {
     $queue = $test_params->{queue} if (defined $test_params->{queue});
     
     $test_params->{domain} = $domain;
-    my $js = JSON->new;
+    my $js = JSON::PP->new;
     $js->canonical( 1 );
     my $encoded_params                 = $js->encode( $test_params );
     my $test_params_deterministic_hash = md5_hex( encode_utf8( $encoded_params ) );
@@ -250,7 +250,7 @@ sub add_batch_job {
     my $batch_id;
 
 	my $dbh = $self->dbh;
-	my $js = JSON->new;
+	my $js = JSON::PP->new;
 	$js->canonical( 1 );
     		
     if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {


### PR DESCRIPTION
Replaced JSON with JSON::PP in modules where JSON::PP, but not JSON, was loaded. This was meant to be fixed in PR #277.

Affected modules: 
* Zonemaster/Backend/DB/MySQL.pm
* Zonemaster/Backend/DB/PostgreSQL.pm
