### PR TITLE
Adjusting the locale environment before the daemons are started

### DIFF
--- a/share/zm-backend.sh-mysql
+++ b/share/zm-backend.sh-mysql
@@ -14,6 +14,13 @@
 #                    database engine.
 ### END INIT INFO
 
+# Unset potentially conflicting locale, setting the default
+unset LANGUAGE
+unset LANG
+unset LC_MESSAGES
+unset LC_ALL
+export LC_CTYPE="en_US.UTF-8"
+
 LOGDIR=/var/log/zonemaster
 PIDDIR=/var/run/zonemaster
 LISTENIP=127.0.0.1

--- a/share/zm-backend.sh-postgresql
+++ b/share/zm-backend.sh-postgresql
@@ -14,6 +14,13 @@
 #                    database engine.
 ### END INIT INFO
 
+# Unset potentially conflicting locale, setting the default
+unset LANGUAGE
+unset LANG
+unset LC_MESSAGES
+unset LC_ALL
+export LC_CTYPE="en_US.UTF-8"
+
 LOGDIR=/var/log/zonemaster
 PIDDIR=/var/run/zonemaster
 LISTENIP=127.0.0.1

--- a/share/zm-centos.sh-mysql
+++ b/share/zm-centos.sh-mysql
@@ -13,6 +13,13 @@
 #                    make up the Zonemaster Backend.
 ### END INIT INFO
 
+# Unset potentially conflicting locale, setting the default
+unset LANGUAGE
+unset LANG
+unset LC_MESSAGES
+unset LC_ALL
+export LC_CTYPE="en_US.UTF-8"
+
 LOGDIR=/var/log/zonemaster
 PIDDIR=/var/run/zonemaster
 LISTENIP=127.0.0.1

--- a/share/zm-centos.sh-postgresql
+++ b/share/zm-centos.sh-postgresql
@@ -13,6 +13,13 @@
 #                    make up the Zonemaster Backend.
 ### END INIT INFO
 
+# Unset potentially conflicting locale, setting the default
+unset LANGUAGE
+unset LANG
+unset LC_MESSAGES
+unset LC_ALL
+export LC_CTYPE="en_US.UTF-8"
+
 LOGDIR=/var/log/zonemaster
 PIDDIR=/var/run/zonemaster
 LISTENIP=127.0.0.1


### PR DESCRIPTION
The language setting via JSON RPC does not work if LANGUAGE is set to something, at least in some OSs. With this fix, to be safe some environment variables are unset, and LC_CTYPE is set to the default locale. With this setting it should work, and it will not be in conflict with anything.

The PR is a work-around for the issue described in issue #350, but this should NOT be considered to be a solution.