### PR TITLE
TestAgent: Fail early if database is inaccessible

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -20,6 +20,10 @@ else {
 }
 
 
+=head1 SUBROUTINES
+
+=cut
+
 sub _load_config {
     my $cfg = Config::IniFiles->new( -file => $path );
     die "UNABLE TO LOAD $path\n" unless ( $cfg );
@@ -169,6 +173,56 @@ sub lock_on_queue {
     return $val;
 }
 
+=head2 new_DB
 
+Create a new database adapter object according to configuration.
+
+The adapter connects to the database before it is returned.
+
+=head3 INPUT
+
+The database adapter class is selected based on the return value
+of L<Zonemaster::Backend::Config->BackendDBType()>. The database
+adapter class constructor is called without arguments and is expected
+to configure itself according to available global configuration.
+
+=back
+
+=head3 RETURNS
+
+A configured L<Zonemaster::Backend::DB> object.
+
+=head3 EXCEPTIONS
+
+=over 4
+
+=item Dies if no database engine type is defined in the configuration.
+
+=item Dies if no adapter for the configured database engine can be loaded.
+
+=item Dies if the adapter is unable to connect to the database.
+
+=back
+
+=cut
+
+sub new_DB {
+    # Get DB type from config
+    my $dbtype = Zonemaster::Backend::Config->BackendDBType();
+    if (!defined $dbtype) {
+        die "Unrecognized DB.engine in backend config";
+    }
+
+    # Load and construct DB adapter
+    my $dbclass = 'Zonemaster::Backend::DB::' . $dbtype;
+    require( join( "/", split( /::/, $dbclass ) ) . ".pm" );
+    $dbclass->import();
+    my $db = $dbclass->new;
+
+    # Connect or die
+    $db->dbh;
+
+    return $db;
+}
 
 1;

--- a/lib/Zonemaster/Backend/Config/DCPlugin.pm
+++ b/lib/Zonemaster/Backend/Config/DCPlugin.pm
@@ -1,0 +1,101 @@
+package Zonemaster::Backend::Config::DCPlugin;
+
+use strict;
+use warnings;
+
+=head1 NAME
+
+Zonemaster::Backend::Config::DCPlugin - Daemon::Control plugin that
+loads the backend configuration.
+
+=head1 SYNOPSIS
+
+Provides validated and sanity-checked backend configuration through the L<config> property.
+
+    my $daemon = Daemon::Control
+        ->with_plugins('+Zonemaster::Backend::Config::DCPlugin')
+        ->new({
+            program => sub {
+                my $self = shift;
+                my $db   = $self->config->{db};
+                ...
+            },
+        });
+
+The configuration is loaded on start and restart. The start/restart
+is aborted if the configuration fails the validity- and sanity check.
+In case of the database configuration, sanity is checked by actually
+connecting to the database.
+
+=head1 AUTHOR
+
+Mattias P, C<< <mattias.paivarinta@iis.se> >>
+
+=cut
+
+use parent 'Daemon::Control';
+
+use Role::Tiny;
+use Class::Method::Modifiers;
+use Zonemaster::Backend::Config;
+
+before do_start   => \&_load_config;
+before do_restart => \&_load_config;
+
+=head1 CLASS VARIABLES
+
+=head2 %config
+
+The loaded configuration.
+
+=cut
+
+our %config;
+
+=head1 PROPERTIES
+
+=head2 config
+
+The loaded configuration.
+
+A hashref with the following keys.
+
+=over 4
+
+=item db
+
+A L<Zonemaster::Backned::DB> object. It's been able to connect to
+the database at least once.
+
+=back
+
+=cut
+
+sub config {
+    return { %config };
+};
+
+=head1 PRIVATE METHODS
+
+=head2 _load_config
+
+Checks if the configuration has been loaded before, and delegates
+to _load_config otherwise.
+
+=cut
+
+sub _load_config {
+    _do_load_config() if !%config;
+}
+
+=head2 _do_load_config
+
+Loads, validates and sanity-checks the backend configuration.
+
+=cut
+
+sub _do_load_config {
+    %config = ( db => Zonemaster::Backend::Config->new_DB() );
+}
+
+1;

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -13,22 +13,11 @@ use Time::HiRes qw[time sleep];
 use Getopt::Long;
 
 ###
-### Global variable.
-###
-
-our $dbclass;
-
-###
 ### Compile-time stuff.
 ###
 
-# Demand-load the database class specified in the configuration.
 BEGIN {
 	$ENV{PERL_JSON_BACKEND} = 'JSON::PP';
-    my $dbtype = Zonemaster::Backend::Config->BackendDBType();
-    $dbclass = 'Zonemaster::Backend::DB::' . $dbtype;
-    require( join( "/", split( /::/, $dbclass ) ) . ".pm" );
-    $dbclass->import();
 }
 
 ###
@@ -92,7 +81,9 @@ $pm->run_on_finish(
 );
 
 sub main {
-    my $db = $dbclass->new;
+    my $self = shift;
+
+    my $db = $self->config->{db};
 
     while ( 1 ) {
         my $id = $db->get_test_request();
@@ -114,7 +105,7 @@ sub main {
 ### Daemon Control stuff.
 ###
 
-my $daemon = Daemon::Control->new({
+my $daemon = Daemon::Control->with_plugins(qw( +Zonemaster::Backend::Config::DCPlugin ))->new({
     name     => 'zonemaster-testagent',
     program  => \&main,
     pid_file => $pidfile,


### PR DESCRIPTION
Make the start and restart commands of zonemaster_backend_testagent
fail before daemonization if the configured database is
inaccessible. This enables us to make service scripts that properly
report errors when the configured database engine isn't installed and
when there's a problem with the database connection configuration.

If the database connection fails early, zonemaster_backend_testagent
exits with a non-zero status and an error message to stderr.