### PR TITLE
Corrected error message for IDN

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -119,7 +119,7 @@ sub _check_domain {
                     $dn,
                     {
                         status  => 'nok',
-                        message => encode_entities( "The domain name cannot be converted to the IDN format" )
+                        message => encode_entities( "The domain name is not a valid IDNA string and cannot be converted to an A-label" )
                     }
                 );
             }
@@ -130,7 +130,7 @@ sub _check_domain {
                 {
                     status => 'nok',
                     message =>
-                      encode_entities( "$type contains non-ascii characters and IDN conversion is not installed" )
+                      encode_entities( "$type contains non-ascii characters and IDNA conversion is not installed" )
                 }
             );
         }


### PR DESCRIPTION
* Corrected error message when a non-ascii domain label cannot be converted to A-label, i.e. it is not a valid IDNA label.
* Corrected error message when there is no support for non-ascii domain labels, i.e. zonemaster-ldns is not built with libidn support.