### PR TITLE
Deprecate validate_syntax

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1028,7 +1028,7 @@ An object with the following properties:
 >
 
 
-## API method: `validate_syntax`
+## API method: `validate_syntax` - **Deprecated**
 
 Checks the `"params"` structure for syntax coherence. It is very strict on what
 is allowed and what is not to avoid any SQL injection and cross site scripting


### PR DESCRIPTION
Update the API Documentation to deprecate the method "validate_syntax"