### PR TITLE
Fix issue #431 - Allow null, string, number as id in json rpc request

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -575,13 +575,13 @@ sub get_batch_job_result {
 
 my $rpc_request = joi->object->props(
     jsonrpc => joi->string->required,
-    id => $zm_validator->jsonrpc_id()->required,
     method => $zm_validator->jsonrpc_method()->required);
 sub jsonrpc_validate {
     my ( $self, $jsonrpc_request) = @_;
 
     my @error_rpc = $rpc_request->validate($jsonrpc_request);
-    return {
+    if (!exists $jsonrpc_request->{"id"} || @error_rpc) {
+        return {
             jsonrpc => '2.0',
             id => undef,
             error => {
@@ -589,7 +589,8 @@ sub jsonrpc_validate {
                 message=> 'The JSON sent is not a valid request object.',
                 data => "@error_rpc\n"
             }
-        } if @error_rpc;
+        }
+    }
 
     if (exists $jsonrpc_request->{"params"}) {
         if ($jsonrpc_request->{"method"} eq "get_ns_ips") {

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -82,6 +82,3 @@ sub username {
 sub jsonrpc_method {
     return joi->string->regex("[a-zA-Z0-9_-]*");
 }
-sub jsonrpc_id {
-    return joi->integer->min(0);
-}


### PR DESCRIPTION
Fix issue #431 - Allow null, string, number as id in json rpc request
