### PR TITLE
Updates for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Follow the detailed [installation instructions](docs/Installation.md).
 
 ### Configuration 
 
-Zonemaster *Backend* is configured as a whole from `/etc/zonemaster/backend_config.ini`.
+Zonemaster *Backend* is configured as a whole from `/etc/zonemaster/backend_config.ini`
+(CentOS, Debian and Ubuntu) or `/usr/local/etc/zonemaster/backend_config.ini`
+(FreeBSD).
 
 >
 > At this time there is no documentation for `backend_config.ini`.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -400,22 +400,30 @@ Install dependencies available from binary packages:
 pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-IO-CaptureOutput p5-JSON-PP p5-JSON-RPC p5-Locale-libintl p5-Moose p5-Parallel-ForkManager p5-Plack p5-Plack-Middleware-Debug p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote
 ```
 
+Optionally install Curl (only needed for the post-installation smoke test)
+
+```sh
+pkg install curl
+```
+
+
 Install dependencies not available from binary packages:
 
 ```sh
-cpan -i Net::IP::XS
+cpanm Net::IP::XS
 ```
 
 Install Zonemaster::Backend:
 
 ```sh
-cpan -i Zonemaster::Backend
+cpanm Zonemaster::Backend
 ```
 
 > The command above might try to install "DBD::Pg" and "DBD::mysql".
 > You can ignore if it fails. The relevant libraries are installed further down in these instructions.
 
 Add `zonemaster` user and group:
+
 ```sh
 pw groupadd zonemaster
 pw useradd zonemaster -g zonemaster -s /sbin/nologin -d /nonexistent -c "Zonemaster daemon user"
@@ -425,8 +433,8 @@ Install files to their proper locations:
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
-install -m 755 -d /etc/zonemaster
-install -m 640 -g zonemaster ./backend_config.ini /etc/zonemaster/
+install -m 755 -d /usr/local/etc/zonemaster
+install -m 640 -g zonemaster ./backend_config.ini /usr/local/etc/zonemaster/
 install -m 775 -g zonemaster -d /var/log/zonemaster
 install -m 775 -g zonemaster -d /var/run/zonemaster
 install -m 755 ./zm_rpcapi-bsd /usr/local/etc/rc.d/zm_rpcapi
@@ -540,7 +548,7 @@ curl -s -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"versi
 The command is expected to give an immediate JSON response similiar to:
 
 ```json
-{ "jsonrpc": "2.0", "id": 1, "result": { "zonemaster_backend": "1.0.7", "zonemaster_engine": "v1.0.14" } }
+{"id":"1","jsonrpc":"2.0","result":{"zonemaster_backend":"2.0.2","zonemaster_engine":"v2.0.6"}}
 ```
 
 

--- a/share/zm_rpcapi-bsd
+++ b/share/zm_rpcapi-bsd
@@ -17,6 +17,8 @@ load_rc_config $name
 : ${zm_rpcapi_logfile="/var/log/zonemaster/${name}.log"}
 : ${zm_rpcapi_listen="127.0.0.1:5000"}
 
+export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.ini"
+
 command="/usr/local/bin/starman"
 command_args="--daemonize --user=${zm_rpcapi_user} --group=${zm_rpcapi_group} --pid=${zm_rpcapi_pidfile} --error-log=${zm_rpcapi_logfile} --listen=${zm_rpcapi_listen} --app /usr/local/bin/zonemaster_backend_rpcapi.psgi"
 pidfile="${zm_rpcapi_pidfile}"

--- a/share/zm_testagent-bsd
+++ b/share/zm_testagent-bsd
@@ -15,6 +15,8 @@ load_rc_config $name
 : ${zm_testagent_group="zonemaster"}
 : ${zm_testagent_pidfile="/var/run/zonemaster/${name}.pid"}
 
+export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.ini"
+
 command="/usr/local/bin/zonemaster_backend_testagent"
 command_args="--user=${zm_testagent_user} --group=${zm_testagent_group} --pidfile=${zm_testagent_pidfile}"
 pidfile="${zm_testagent_pidfile}"


### PR DESCRIPTION
* Consistency uses /usr/local/etc/zonemaster (instead of /etc/zonemaster)
  in all four files for FreeBSD
* Use cpanm instead of cpan in Installation.pm
* Minor updates for FreeBSD in Installation.pm