### PR TITLE
Add perl-doc for Debian/Ubuntu

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -204,7 +204,7 @@ sv_SE.utf8
 Install dependencies available from binary packages:
 
 ```sh
-sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl libplack-middleware-reverseproxy-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl starman
+sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl libplack-middleware-reverseproxy-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl perl-doc starman
 ```
 
 > **Note**: libio-stringy-perl is listed here even though it's not a direct


### PR DESCRIPTION
## Purpose

`zmb` requires `perldoc` but that is not included in default Ubuntu installation.

## Context

Fixes #861.

## Changes

Updates installation instruction for Debian/Ubuntu.

## How to test this PR

On a clean Ubuntu, install backend following the instructions, and then run `zmb man`. Then manual should come up with the help of `perldoc`.