### PR TITLE
Run several Test Agents against the same queue

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -231,7 +231,8 @@ sub test_progress {
         # It is always 0 before. Require it to be 0 to prevent race condition
         # between multiple test agents on the same queue.
         if ( $progress == 1 ) {
-            unless ($dbh->do(
+
+            my $updated = $dbh->do(
                         q[
                           UPDATE test_results
                           SET progress = 1,
@@ -242,7 +243,8 @@ sub test_progress {
                         undef,
                         $self->format_time( time() ),
                         $test_id,
-                    )) {
+                );
+            if ($updated eq '0E0') { # It means zero
                 return undef;
             }
         }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -112,8 +112,10 @@ sub run {
                 my ( $entry ) = @_;
                 if ( $entry->{tag} and $entry->{tag} eq 'TEST_CASE_END' ) {
                     $nbr_testcases_finished++;
-                    # limit to max 99%, 100% is reached when data is stored in database
+                    # Must be at least 2% (0 and 1 are special) and limit to max 99%, 100% is reached when
+                    # data is stored in database
                     my $progress_percent = int( 99 * $nbr_testcases_finished /  $nbr_testcases_planned );
+                    $progress_percent = 2 if $progress_percent < 2;
                     $self->{_db}->test_progress( $test_id, $progress_percent );
                 }
             }


### PR DESCRIPTION
## Purpose

When a large batch is to be tested, adding several Test Agents increases performance if the server has large capacity. Several servers could also be used. One limitation is that current code only allows one Test Agent per queue. All tests in a batch always belong to the same queue.

This PR makes it possible for several Test Agents to fetch un-run tests from the same queue without the risk of two or more Test Agents testing the same item.

This PR does not handle possible race condition between multiple Test Agents when it comes to `process_unfinished_tests()`, but that could be worked-around by setting a longer `ZONEMASTER_max_zonemaster_execution_time` on all Test Agents except one.

This PR also ensures that the progress counter is never set to 0% or 1% during the testing phase.

## Changes

* lib/Zonemaster/Backend/DB.pm
* lib/Zonemaster/Backend/TestAgent.pm


## How to test this PR

* Run a large batch with one Test Agent and nothing should be changed.
* Run a large batch with two Test Agents (the same queue) and there should be no cases when the same test is run by more than one worker.
