### PR TITLE
RPCAPI: call Translator’s instance() method, instead of new()

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -401,7 +401,7 @@ sub get_test_results {
         my $locale = $self->_get_locale( $params );
 
         my $translator;
-        $translator = Zonemaster::Backend::Translator->new;
+        $translator = Zonemaster::Backend::Translator->instance();
 
         my $previous_locale = $translator->locale;
         if ( !$translator->locale( $locale ) ) {


### PR DESCRIPTION
## Purpose

This PR fixes a bug causing the RPCAPI to only work once, before always returning HTTP 500 errors until the daemon is restarted.

## Context

When RPCAPI needs a Translator, it called the latter module’s `new()` method, instead of `instance()`.

It’s a singleton object, so calling a method named `new()` makes no sense. It is also marked as deprecated in the documentation. Besides, after a recent refactoring of `Zonemaster::Engine::Translator`, `new()` is no longer idempotent: calling it repeatedly will crash the program. And indeed, calling the `get_test_results` RPCAPI method only worked once, then always returned an error until the RPCAPI daemon is restarted.

**Note**: this change requires merging of https://github.com/zonemaster/zonemaster-engine/pull/1347 in Engine.

## Changes

- Call `instance()` instead of `new()`.

## How to test this PR

**Prerequisites**: PR https://github.com/zonemaster/zonemaster-engine/pull/1347 needs to be merged first.

Run the unit test suite, or at least `t/test01.t`; expect no errors. One of the symptoms of the problem being fixed by this PR is that the `t/test01.t` test script did not pass.

Get a hold of a test ID from a previous domain test in the database, or run a dummy test (e.g. `zmtest localhost`).

Then, run `zmb get_test_results --test-id $TEST_ID --lang $LANGUAGE` as many times as there are RPCAPI workers (by default, 5), where `$TEST_ID` is the ID of any previous test and `$LANGUAGE` is any supported language. Then, run the same command a few times more and expect no errors on output.