### PR TITLE
CI: Target Perl version 5.42

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         db: [sqlite, mysql, postgresql]
-        perl: ['5.40']
+        perl: ['5.42']
         include:
           - db: sqlite
             perl: '5.36'


### PR DESCRIPTION
## Purpose

This PR updates the list of Perls tested against, replacing Perl 5.40 with Perl 5.42.

## Context

Recent release of Perl 5.42.2 (https://www.nntp.perl.org/group/perl.perl5.porters/2026/03/msg270839.html).

## Changes

 * Change Perl 5.40 to 5.42 in `.github/workflows/ci.yml`.

## How to test this PR

N/A.
