### PR TITLE
Add schema version

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -82,6 +82,7 @@ t/db_schema_version.t
 t/idn.data
 t/idn.t
 t/lifecycle.t
+t/log.t
 t/parameters_validation.t
 t/queue.t
 t/rpc_validation.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -53,6 +53,7 @@ share/locale/nb/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/sl/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-Backend.mo
 share/Makefile
+share/patch/patch_db_schema_version_1.pl
 share/patch/patch_db_zonemaster_backend_ver_11.1.0.pl
 share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
 share/patch/patch_db_zonemaster_backend_ver_9.0.0.pl
@@ -77,6 +78,7 @@ t/batches.t
 t/config.t
 t/db.t
 t/db_ddl.t
+t/db_schema_version.t
 t/idn.data
 t/idn.t
 t/lifecycle.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,14 +35,16 @@ requires
   'Router::Simple::Declare'         => 0,
   'Starman'                         => 0,
   'Try::Tiny'                       => 0.12,
-  'Zonemaster::LDNS'                => 5.000001,  # v5.0.1
-  'Zonemaster::Engine'              => 8.001000,  # v8.1.0
+  'Zonemaster::LDNS'                => 5.000001,    # v5.0.1
+  'Zonemaster::Engine'              => 8.001000,    # v8.1.0
   ;
 
+test_requires 'Capture::Tiny';
 test_requires 'DBD::SQLite' => 1.66;
 test_requires 'Test::Differences';
+test_requires 'Test::Fatal';
 test_requires 'Test::Exception';
-test_requires 'Time::Local' => 1.26;
+test_requires 'Time::Local'      => 1.26;
 test_requires 'Test::NoWarnings' => 0;
 
 recommends 'DBD::mysql';
@@ -61,21 +63,20 @@ no_index directory => 'Doc';
 
 # Make all platforms include inc/Module/Install/External.pm
 requires_external_bin 'find';
-if ($^O eq "freebsd") {
+if ( $^O eq "freebsd" ) {
     requires_external_bin 'gmake';
-};
+}
 
 sub MY::postamble {
     my $text;
-    if ($^O eq "freebsd") {
+    if ( $^O eq "freebsd" ) {
+
         # Make FreeBSD use gmake for share/Makefile
-        $text = 'GMAKE ?= "gmake"' . "\n"
-            . 'pure_all :: share/Makefile' . "\n"
-            . "\t" . 'cd share && $(GMAKE) all' . "\n";
-    } else {
-        $text = 'pure_all :: share/Makefile' . "\n"
-            . "\t" . 'cd share && $(MAKE) all' . "\n";
-    };
+        $text = 'GMAKE ?= "gmake"' . "\n" . 'pure_all :: share/Makefile' . "\n" . "\t" . 'cd share && $(GMAKE) all' . "\n";
+    }
+    else {
+        $text = 'pure_all :: share/Makefile' . "\n" . "\t" . 'cd share && $(MAKE) all' . "\n";
+    }
     my $docker = <<'END_DOCKER';
 
 docker-build:
@@ -90,7 +91,7 @@ docker-tag-latest:
 END_DOCKER
 
     return $text . $docker;
-};
+}
 
 install_share;
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -9,8 +9,8 @@ use Carp qw( confess croak );
 use Config::IniFiles;
 use Config;
 use File::ShareDir qw[dist_file];
-use File::Slurp qw( read_file );
-use Log::Any qw( $log );
+use File::Slurp    qw( read_file );
+use Log::Any       qw( $log );
 use Readonly;
 use Zonemaster::Backend::Validator qw( :untaint );
 use Zonemaster::Backend::DB;
@@ -189,7 +189,7 @@ sub parse {
 
     my $get_and_clear = sub {    # Read and clear a property from a Config::IniFiles object.
         my ( $section, $param ) = @_;
-        my ( $value, @extra ) = $ini->val( $section, $param );
+        my ( $value,   @extra ) = $ini->val( $section, $param );
         if ( @extra ) {
             die "Property not unique: $section.$param\n";
         }
@@ -199,18 +199,7 @@ sub parse {
 
     # Validate section names
     {
-        my %sections = map { $_ => 1 } ( 'DB',
-                                         'MYSQL',
-                                         'POSTGRESQL',
-                                         'SQLITE',
-                                         'LANGUAGE',
-                                         'PUBLIC PROFILES',
-                                         'PRIVATE PROFILES',
-                                         'ZONEMASTER',
-                                         'METRICS',
-                                         'RPCAPI',
-                                         'TLD URL SETTINGS',
-                                         'TLD URL OVERRIDE');
+        my %sections = map { $_ => 1 } ( 'DB', 'MYSQL', 'POSTGRESQL', 'SQLITE', 'LANGUAGE', 'PUBLIC PROFILES', 'PRIVATE PROFILES', 'ZONEMASTER', 'METRICS', 'RPCAPI', 'TLD URL SETTINGS', 'TLD URL OVERRIDE' );
         for my $section ( $ini->Sections ) {
             if ( !exists $sections{$section} ) {
                 die "config: unrecognized section: $section\n";
@@ -230,8 +219,8 @@ sub parse {
     $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( '20' );
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
-    $obj->_set_RPCAPI_enable_user_create( 'no' ); # experimental
-    $obj->_set_RPCAPI_enable_batch_create( 'yes' ); # experimental
+    $obj->_set_RPCAPI_enable_user_create( 'no' );      # experimental
+    $obj->_set_RPCAPI_enable_batch_create( 'yes' );    # experimental
     $obj->_set_RPCAPI_enable_add_api_user( 'no' );
     $obj->_set_RPCAPI_enable_add_batch_job( 'yes' );
     $obj->_set_locales( 'en_US' );
@@ -250,6 +239,7 @@ sub parse {
 
     # Check deprecated properties and assign fallback values
     my @warnings;
+
     #currently no deprecation warnings
 
     # Assign property values (part 2/2)
@@ -328,7 +318,8 @@ sub parse {
         }
         $obj->_set_RPCAPI_enable_add_api_user( $value );
         $obj->_set_RPCAPI_enable_user_create( $value );
-    } else {
+    }
+    else {
         if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
             $obj->_set_RPCAPI_enable_add_api_user( $value );
             $obj->_set_RPCAPI_enable_user_create( $value );
@@ -340,7 +331,8 @@ sub parse {
         }
         $obj->_set_RPCAPI_enable_add_batch_job( $value );
         $obj->_set_RPCAPI_enable_batch_create( $value );
-    } else {
+    }
+    else {
         if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
             $obj->_set_RPCAPI_enable_add_batch_job( $value );
             $obj->_set_RPCAPI_enable_batch_create( $value );
@@ -359,7 +351,7 @@ sub parse {
         my $path = $get_and_clear->( 'PRIVATE PROFILES', $name );
         $obj->_add_private_profile( $name, $path );
     }
-    
+
     for my $name ( $ini->Parameters( 'TLD URL OVERRIDE' ) ) {
         my $path = $get_and_clear->( 'TLD URL OVERRIDE', $name );
         $obj->_add_tld_url_override( $name, $path );
@@ -438,7 +430,6 @@ sub check_db {
 
     return _normalize_engine_type( $db );
 }
-
 
 =head2 DB_engine
 
@@ -729,8 +720,8 @@ sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMA
 sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
 sub METRICS_statsd_host                                 { return $_[0]->{_METRICS_statsd_host}; }
 sub METRICS_statsd_port                                 { return $_[0]->{_METRICS_statsd_port}; }
-sub RPCAPI_enable_user_create                           { return $_[0]->{_RPCAPI_enable_user_create}; } # experimental
-sub RPCAPI_enable_batch_create                          { return $_[0]->{_RPCAPI_enable_batch_create}; } # experimental
+sub RPCAPI_enable_user_create                           { return $_[0]->{_RPCAPI_enable_user_create}; }                             # experimental
+sub RPCAPI_enable_batch_create                          { return $_[0]->{_RPCAPI_enable_batch_create}; }                            # experimental
 sub RPCAPI_enable_add_api_user                          { return $_[0]->{_RPCAPI_enable_add_api_user}; }
 sub RPCAPI_enable_add_batch_job                         { return $_[0]->{_RPCAPI_enable_add_batch_job}; }
 
@@ -758,35 +749,39 @@ UNITCHECK {
     _create_setter( '_set_ZONEMASTER_age_reuse_previous_test',                  '_ZONEMASTER_age_reuse_previous_test',                  \&untaint_strictly_positive_int );
     _create_setter( '_set_METRICS_statsd_host',                                 '_METRICS_statsd_host',                                 \&untaint_host );
     _create_setter( '_set_METRICS_statsd_port',                                 '_METRICS_statsd_port',                                 \&untaint_strictly_positive_int );
-    _create_setter( '_set_RPCAPI_enable_user_create',                           '_RPCAPI_enable_user_create',                           \&untaint_bool ); # experimental
-    _create_setter( '_set_RPCAPI_enable_batch_create',                          '_RPCAPI_enable_batch_create',                          \&untaint_bool ); # experimental
+    _create_setter( '_set_RPCAPI_enable_user_create',                           '_RPCAPI_enable_user_create',                           \&untaint_bool );                       # experimental
+    _create_setter( '_set_RPCAPI_enable_batch_create',                          '_RPCAPI_enable_batch_create',                          \&untaint_bool );                       # experimental
     _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool );
     _create_setter( '_set_RPCAPI_enable_add_batch_job',                         '_RPCAPI_enable_add_batch_job',                         \&untaint_bool );
 }
 
-
-=head2 new_DB
+=head2 new_DB( %opts )
 
 Create a new database adapter object according to configuration.
 
-The adapter connects to the database before it is returned.
+=head3 INPUTS
 
-=head3 INPUT
+Options:
 
-The database adapter class is selected based on the return value of
-L<DB_engine>.
-The database adapter class constructor is called without arguments and is
-expected to configure itself according to available global configuration.
+=over 4
+
+=item override_dbtype
+
+A L<DB.engine|https://doc.zonemaster.net/latest/configuration/backend.md#engine> value.
+Determines the database adapter class to invoke.
+If not provided, the value of DB.engine is used.
+
+=back
 
 =head3 RETURNS
 
-A configured L<Zonemaster::Backend::DB> object.
+A configured and connected L<Zonemaster::Backend::DB> object.
 
 =head3 EXCEPTIONS
 
 =over 4
 
-=item Dies if no adapter for the configured database engine can be loaded.
+=item Dies if an invalid option is given.
 
 =item Dies if the adapter is unable to connect to the database.
 
@@ -795,9 +790,15 @@ A configured L<Zonemaster::Backend::DB> object.
 =cut
 
 sub new_DB {
-    my ( $self ) = @_;
+    my ( $self, %opts ) = @_;
 
-    my $dbtype  = $self->DB_engine;
+    my $dbtype_opt = delete $opts{override_dbtype};
+
+    if ( %opts ) {
+        croak 'Unrecognized options: ' . join( ', ', sort keys %opts );
+    }
+
+    my $dbtype  = $self->check_db( $dbtype_opt // $self->DB_engine );
     my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
     my $db      = $dbclass->from_config( $self );
 
@@ -958,24 +959,23 @@ sub _add_tld_url_override {
     my ( $self, $tld, $value ) = @_;
 
     unless ( untaint_tld_label( $tld ) ) {
-      die "Invalid TLD label in TLD URL OVERRIDE section: $tld\n";
+        die "Invalid TLD label in TLD URL OVERRIDE section: $tld\n";
     }
 
     if ( exists $self->{_tld_url_override}{$tld} ) {
         die "TLD label not unique: $tld\n";
     }
 
-    unless ( untaint_tld_block( $value ) or
-             untaint_tld_url_no_path(  $value ) or
-             untaint_tld_url_string( $value ) ) {
+    unless ( untaint_tld_block( $value )
+        or untaint_tld_url_no_path( $value )
+        or untaint_tld_url_string( $value ) )
+    {
         die "Invalid value for a TLD label key: $value\n";
     }
 
     $self->{_tld_url_override}{$tld} = $value;
     return;
 }
-
-
 
 # Create a setter method with a given name using the given field and validator
 sub _create_setter {

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -149,7 +149,7 @@ Construct a new Zonemaster::Backend::Config based on a given configuration.
     );
 
 The configuration is interpreted according to the
-L<configuration format specification|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md>.
+L<configuration format specification|https://doc.zonemaster.net/latest/configuration/backend.html>.
 
 Returns a new Zonemaster::Backend::Config instance with its properties set to
 normalized and untainted values according to the given configuration with
@@ -442,7 +442,7 @@ sub check_db {
 
 =head2 DB_engine
 
-Get the value of L<DB.engine|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#engine>.
+Get the value of L<DB.engine|https://doc.zonemaster.net/latest/configuration/backend.html#engine>.
 
 Returns one of C<"SQLite">, C<"PostgreSQL"> or C<"MySQL">.
 
@@ -465,28 +465,28 @@ sub _set_DB_engine {
 
 =head2 DB_polling_interval
 
-Get the value of L<DB.polling_interval|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#polling_interval>.
+Get the value of L<DB.polling_interval|https://doc.zonemaster.net/latest/configuration/backend.html#polling_interval>.
 
 Returns a number.
 
 
 =head2 MYSQL_database
 
-Get the value of L<MYSQL.database|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#database>.
+Get the value of L<MYSQL.database|https://doc.zonemaster.net/latest/configuration/backend.md#database>.
 
 Returns a string.
 
 
 =head2 MYSQL_host
 
-Get the value of L<MYSQL.host|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#host>.
+Get the value of L<MYSQL.host|https://doc.zonemaster.net/latest/configuration/backend.md#host>.
 
 Returns a string.
 
 
 =head2 MYSQL_port
 
-Returns the L<MYSQL.port|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#port>
+Returns the L<MYSQL.port|https://doc.zonemaster.net/latest/configuration/backend.md#port>
 property from the loaded config.
 
 Returns a number.
@@ -494,35 +494,35 @@ Returns a number.
 
 =head2 MYSQL_password
 
-Get the value of L<MYSQL.password|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#password>.
+Get the value of L<MYSQL.password|https://doc.zonemaster.net/latest/configuration/backend.md#password>.
 
 Returns a string.
 
 
 =head2 MYSQL_user
 
-Get the value of L<MYSQL.user|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#user>.
+Get the value of L<MYSQL.user|https://doc.zonemaster.net/latest/configuration/backend.md#user>.
 
 Returns a string.
 
 
 =head2 POSTGRESQL_database
 
-Get the value of L<POSTGRESQL.database|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#database-1>.
+Get the value of L<POSTGRESQL.database|https://doc.zonemaster.net/latest/configuration/backend.md#database-1>.
 
 Returns a string.
 
 
 =head2 POSTGRESQL_host
 
-Get the value of L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#host-1>.
+Get the value of L<POSTGRESQL.host|https://doc.zonemaster.net/latest/configuration/backend.md#host-1>.
 
 Returns a string.
 
 
 =head2 POSTGRESQL_port
 
-Returns the L<POSTGRESQL.port|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#port-1>
+Returns the L<POSTGRESQL.port|https://doc.zonemaster.net/latest/configuration/backend.md#port-1>
 property from the loaded config.
 
 Returns a number.
@@ -530,28 +530,28 @@ Returns a number.
 
 =head2 POSTGRESQL_password
 
-Get the value of L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#password-1>.
+Get the value of L<POSTGRESQL.password|https://doc.zonemaster.net/latest/configuration/backend.md#password-1>.
 
 Returns a string.
 
 
 =head2 POSTGRESQL_user
 
-Get the value of L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#user-1>.
+Get the value of L<POSTGRESQL.user|https://doc.zonemaster.net/latest/configuration/backend.md#user-1>.
 
 Returns a string.
 
 
 =head2 SQLITE_database_file
 
-Get the value of L<SQLITE.database_file|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#database_file>.
+Get the value of L<SQLITE.database_file|https://doc.zonemaster.net/latest/configuration/backend.md#database_file>.
 
 Returns a string.
 
 
 =head2 LANGUAGE_locale
 
-Get the value of L<LANGUAGE.locale|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#locale>.
+Get the value of L<LANGUAGE.locale|https://doc.zonemaster.net/latest/configuration/backend.md#locale>.
 
 Returns a mapping from two-letter locale tag prefixes to full locale tags.
 This is represented by a hash mapping prefix to full locale tag.
@@ -566,7 +566,7 @@ E.g.:
 
 =head2 PUBLIC_PROFILES
 
-Get the set of L<PUBLIC PROFILES|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#public-profiles-and-private-profiles-sections>.
+Get the set of L<PUBLIC PROFILES|https://doc.zonemaster.net/latest/configuration/backend.md#public-profiles-and-private-profiles-sections>.
 
 Returns a hash mapping profile names to profile paths.
 The profile names are normalized to lowercase.
@@ -576,7 +576,7 @@ C<undef> means that the Zonemaster Engine default profile should be used.
 
 =head2 PRIVATE_PROFILES
 
-Get the set of L<PRIVATE PROFILES|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#public-profiles-and-private-profiles-sections>.
+Get the set of L<PRIVATE PROFILES|https://doc.zonemaster.net/latest/configuration/backend.md#public-profiles-and-private-profiles-sections>.
 
 Returns a hash mapping profile names to profile paths.
 The profile names are normalized to lowercase.
@@ -614,7 +614,7 @@ L<URL string or blocking policy|https://github.com/zonemaster/zonemaster/blob/ma
 
 =head2 ZONEMASTER_max_zonemaster_execution_time
 
-Get the value of L<ZONEMASTER.max_zonemaster_execution_time|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#max_zonemaster_execution_time>.
+Get the value of L<ZONEMASTER.max_zonemaster_execution_time|https://doc.zonemaster.net/latest/configuration/backend.md#max_zonemaster_execution_time>.
 
 Returns a number.
 
@@ -622,7 +622,7 @@ Returns a number.
 =head2 ZONEMASTER_number_of_processes_for_frontend_testing
 
 Get the value of
-L<ZONEMASTER.number_of_processes_for_frontend_testing|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#number_of_processes_for_frontend_testing>.
+L<ZONEMASTER.number_of_processes_for_frontend_testing|https://doc.zonemaster.net/latest/configuration/backend.md#number_of_processes_for_frontend_testing>.
 
 Returns a number.
 
@@ -630,7 +630,7 @@ Returns a number.
 =head2 ZONEMASTER_number_of_processes_for_batch_testing
 
 Get the value of
-L<ZONEMASTER.number_of_processes_for_batch_testing|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#number_of_processes_for_batch_testing>.
+L<ZONEMASTER.number_of_processes_for_batch_testing|https://doc.zonemaster.net/latest/configuration/backend.md#number_of_processes_for_batch_testing>.
 
 Returns a number.
 
@@ -638,7 +638,7 @@ Returns a number.
 =head2 ZONEMASTER_lock_on_queue
 
 Get the value of
-L<ZONEMASTER.lock_on_queue|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#lock_on_queue>.
+L<ZONEMASTER.lock_on_queue|https://doc.zonemaster.net/latest/configuration/backend.md#lock_on_queue>.
 
 Returns a number.
 
@@ -646,7 +646,7 @@ Returns a number.
 =head2 ZONEMASTER_age_reuse_previous_test
 
 Get the value of
-L<ZONEMASTER.age_reuse_previous_test|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#age_reuse_previous_test>.
+L<ZONEMASTER.age_reuse_previous_test|https://doc.zonemaster.net/latest/configuration/backend.md#age_reuse_previous_test>.
 
 Returns a number.
 
@@ -654,7 +654,7 @@ Returns a number.
 =head2 METRICS_statsd_host
 
 Get the value of
-L<METRICS.statsd_host|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#statsd_host>.
+L<METRICS.statsd_host|https://doc.zonemaster.net/latest/configuration/backend.md#statsd_host>.
 
 Returns a string.
 
@@ -662,7 +662,7 @@ Returns a string.
 =head2 METRICS_statsd_port
 
 Get the value of
-L<METRICS.statsd_host|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#statsd_port>.
+L<METRICS.statsd_host|https://doc.zonemaster.net/latest/configuration/backend.md#statsd_port>.
 
 Returns a number.
 
@@ -671,7 +671,7 @@ Returns a number.
 
 Experimental.
 Get the value of
-L<RPCAPI.enable_user_create|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_user_create>.
+L<RPCAPI.enable_user_create|https://doc.zonemaster.net/latest/configuration/backend.md#enable_user_create>.
 
 Return 0 or 1
 
@@ -680,7 +680,7 @@ Return 0 or 1
 
 Experimental.
 Get the value of
-L<RPCAPI.enable_batch_create|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_batch_create>.
+L<RPCAPI.enable_batch_create|https://doc.zonemaster.net/latest/configuration/backend.md#enable_batch_create>.
 
 Return 0 or 1
 
@@ -688,7 +688,7 @@ Return 0 or 1
 =head2 RPCAPI_enable_add_api_user
 
 Get the value of
-L<RPCAPI.enable_add_api_user|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_add_api_user>.
+L<RPCAPI.enable_add_api_user|https://doc.zonemaster.net/latest/configuration/backend.md#enable_add_api_user>.
 
 Return 0 or 1
 
@@ -696,7 +696,7 @@ Return 0 or 1
 =head2 RPCAPI_enable_add_batch_job
 
 Get the value of
-L<RPCAPI.enable_add_batch_job|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_add_batch_job>.
+L<RPCAPI.enable_add_batch_job|https://doc.zonemaster.net/latest/configuration/backend.md#enable_add_batch_job>.
 
 Return 0 or 1
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -6,8 +6,9 @@ use Moose::Role;
 
 use 5.14.2;
 
-use DBI qw(:sql_types);
-use Digest::MD5 qw(md5_hex);
+use Carp        qw( croak );
+use DBI         qw( :sql_types );
+use Digest::MD5 qw( md5_hex );
 use Encode;
 use Exporter qw( import );
 use JSON::PP;
@@ -28,6 +29,7 @@ requires qw(
   get_dbh_specific_attributes
   get_relative_start_time
   is_duplicate
+  is_unknown_table
 );
 
 has 'data_source_name' => (
@@ -53,6 +55,14 @@ has 'dbhandle' => (
     isa      => 'Maybe[DBI::db]',
     required => 1,
 );
+
+=head2 $REQUIRED_SCHEMA_VERSION
+
+A positive integer. The database schema version that this module is compatible with.
+
+=cut
+
+Readonly our $REQUIRED_SCHEMA_VERSION => 1;
 
 =head2 $TEST_WAITING
 
@@ -154,6 +164,66 @@ sub dbh {
     $self->dbhandle( $dbh );
 
     return $self->dbhandle;
+}
+
+=head2 get_schema_version
+
+Detect the schema version of the database.
+
+Returns an unsigned integer.
+
+The C<0> value means the database is in a schema state prior to schema versioning.
+
+=cut
+
+sub get_schema_version {
+    my ( $self ) = @_;
+
+    my $dbh = $self->dbh;
+
+    local $dbh->{RaiseError} = 0;
+    local $dbh->{PrintError} = 0;
+    my $result = $dbh->selectcol_arrayref( "SELECT version FROM schema_version LIMIT 2" );
+
+    if ( $dbh->err ) {
+        if ( !$self->is_unknown_table ) {
+            croak "Failed to read schema version: " . $dbh->errstr;
+        }
+
+        return 0;
+    }
+
+    if (   @$result != 1
+        || !defined $result->[0]
+        || $result->[0] !~ qr{^[1-9][0-9]*$}
+        || $result->[0] < 1 )
+    {
+        croak 'Invalid schema version declaration';
+    }
+
+    return $result->[0];
+}
+
+=head2 assert_compatible_schema
+
+Assert that the database has a schema version that is compatible with this version of
+Zonemaster Backend.
+
+Croaks if the database has an incompatible schema version, or if it is in an illegal state
+with regard to schema version encoding.
+
+=cut
+
+sub assert_compatible_schema {
+    my ( $self ) = @_;
+
+    my $db_schema_version = $self->get_schema_version;
+
+    if ( $db_schema_version ne $REQUIRED_SCHEMA_VERSION ) {
+        croak "Expected schema version $REQUIRED_SCHEMA_VERSION, found $db_schema_version";
+    }
+
+    return;
 }
 
 sub add_api_user {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -205,6 +205,26 @@ sub create_schema {
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'users' table", data => $dbh->errstr() );
 
+    ####################################################################
+    # SCHEMA VERSION
+    ####################################################################
+    $dbh->do(
+        "CREATE TABLE IF NOT EXISTS schema_version (
+            id INTEGER PRIMARY KEY,
+            version INTEGER NOT NULL,
+            CHECK (id = 1),
+            CHECK (version >= 1)
+        )"
+      )
+      or die Zonemaster::Backend::Error::Internal->new(
+        reason => "Failed to create 'schema_version' table",
+        data   => $dbh->errstr()
+      );
+
+    if ( !defined $dbh->selectrow_array( "SELECT 1 FROM schema_version LIMIT 1" ) ) {
+        $dbh->do( "INSERT INTO schema_version (id, version) VALUES (1, ?)", {}, $Zonemaster::Backend::DB::REQUIRED_SCHEMA_VERSION );
+    }
+
     return;
 }
 
@@ -234,6 +254,7 @@ sub drop_tables {
         }
     }
 
+    $self->dbh->do( "DROP TABLE IF EXISTS schema_version" );
     $self->dbh->do( "DROP TABLE IF EXISTS test_results" );
     $self->dbh->do( "DROP TABLE IF EXISTS result_entries" );
     $self->dbh->do( "DROP TABLE IF EXISTS log_level" );
@@ -336,6 +357,15 @@ sub is_duplicate {
     # https://mariadb.com/kb/en/mariadb-error-codes/
     # https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
     return ( $self->dbh->err == 1062 );
+}
+
+sub is_unknown_table {
+    my ( $self ) = @_;
+
+    # for the list of codes see:
+    # https://mariadb.com/kb/en/mariadb-error-codes/
+    # https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+    return ( $self->dbh->err == 1146 );
 }
 
 no Moose;

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -184,6 +184,26 @@ sub create_schema {
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'users' table", data => $dbh->errstr() );
 
+    ####################################################################
+    # SCHEMA VERSION
+    ####################################################################
+    $dbh->do(
+        "CREATE TABLE IF NOT EXISTS schema_version (
+            id INTEGER PRIMARY KEY,
+            version INTEGER NOT NULL,
+            CHECK (id = 1),
+            CHECK (version >= 1)
+        )"
+      )
+      or die Zonemaster::Backend::Error::Internal->new(
+        reason => "Failed to create 'schema_version' table",
+        data   => $dbh->errstr()
+      );
+
+    if ( !defined $dbh->selectrow_array( "SELECT 1 FROM schema_version LIMIT 1" ) ) {
+        $dbh->do( "INSERT INTO schema_version (id, version) VALUES (1, ?)", {}, $Zonemaster::Backend::DB::REQUIRED_SCHEMA_VERSION );
+    }
+
     return;
 }
 
@@ -203,6 +223,7 @@ sub drop_tables {
     $self->dbh->do( "SET client_min_messages = warning" );
 
     try {
+        $self->dbh->do( "DROP TABLE IF EXISTS schema_version CASCADE" );
         $self->dbh->do( "DROP TABLE IF EXISTS test_results CASCADE" );
         $self->dbh->do( "DROP TABLE IF EXISTS result_entries CASCADE" );
         $self->dbh->do( "DROP TABLE IF EXISTS log_level" );
@@ -304,9 +325,23 @@ sub get_relative_start_time {
 sub is_duplicate {
     my ( $self ) = @_;
 
+    my $state = $self->dbh->state;
+
     # for the list of codes see:
     # https://www.postgresql.org/docs/current/errcodes-appendix.html
-    return ( $self->dbh->state == 23505 );
+    return defined $state
+      && $state eq '23505';
+}
+
+sub is_unknown_table {
+    my ( $self ) = @_;
+
+    my $state = $self->dbh->state;
+
+    # for the list of codes see:
+    # https://www.postgresql.org/docs/current/errcodes-appendix.html
+    return defined $state
+      && $state eq '42P01';
 }
 
 no Moose;

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -183,6 +183,26 @@ sub create_schema {
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'users' table", data => $dbh->errstr() );
 
+    ####################################################################
+    # SCHEMA VERSION
+    ####################################################################
+    $dbh->do(
+        "CREATE TABLE IF NOT EXISTS schema_version (
+            id INTEGER PRIMARY KEY,
+            version INTEGER NOT NULL,
+            CHECK (id = 1),
+            CHECK (version >= 1)
+        )"
+      )
+      or die Zonemaster::Backend::Error::Internal->new(
+        reason => "Failed to create 'schema_version' table",
+        data   => $dbh->errstr()
+      );
+
+    if ( !defined $dbh->selectrow_array( "SELECT 1 FROM schema_version LIMIT 1" ) ) {
+        $dbh->do( "INSERT INTO schema_version (id, version) VALUES (1, ?)", {}, $Zonemaster::Backend::DB::REQUIRED_SCHEMA_VERSION );
+    }
+
     return;
 }
 
@@ -195,8 +215,9 @@ Drop all the tables if they exist.
 sub drop_tables {
     my ( $self ) = @_;
 
-    $self->dbh->do( "DROP TABLE IF EXISTS test_results" );
+    $self->dbh->do( "DROP TABLE IF EXISTS schema_version" );
     $self->dbh->do( "DROP TABLE IF EXISTS result_entries" );
+    $self->dbh->do( "DROP TABLE IF EXISTS test_results" );
     $self->dbh->do( "DROP TABLE IF EXISTS log_level" );
     $self->dbh->do( "DROP TABLE IF EXISTS users" );
     $self->dbh->do( "DROP TABLE IF EXISTS batch_jobs" );
@@ -293,6 +314,14 @@ sub is_duplicate {
 
     # for the list of codes see: https://sqlite.org/rescode.html
     return ( $self->dbh->err == 2067 );
+}
+
+sub is_unknown_table {
+    my ( $self ) = @_;
+
+    # for the list of codes see: https://sqlite.org/rescode.html
+    return ( $self->dbh->err == 1 )
+      && $self->dbh->errstr =~ /^no such table: /;
 }
 
 no Moose;

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -5,32 +5,32 @@ use warnings;
 use 5.14.2;
 
 # Public Modules
-use DBI qw(:utils);
-use Digest::MD5 qw(md5_hex);
-use File::Slurp qw(append_file);
+use DBI         qw( :utils );
+use Digest::MD5 qw( md5_hex );
+use Encode;
+use File::Slurp qw( append_file );
 use HTML::Entities;
 use JSON::PP;
 use JSON::Validator::Joi;
-use Log::Any qw($log);
-use Mojo::JSON::Pointer;
-use Scalar::Util qw(blessed);
 use JSON::Validator::Schema::Draft7;
-use Locale::TextDomain qw[Zonemaster-Backend];
-use Locale::Messages qw[LC_MESSAGES LC_ALL];
-use POSIX qw (setlocale);
-use Encode;
+use Locale::Messages   qw( LC_MESSAGES LC_ALL );
+use Locale::TextDomain qw( Zonemaster-Backend );
+use Log::Any           qw( $log );
+use Mojo::JSON::Pointer;
+use POSIX        qw( setlocale );
+use Scalar::Util qw( blessed );
 
 # Zonemaster Modules
-use Zonemaster::Engine;
+use Zonemaster::Backend::Config;
+use Zonemaster::Backend::Errors;
+use Zonemaster::Backend::TLD_URL;
+use Zonemaster::Backend::Translator;
+use Zonemaster::Backend::Validator;
+use Zonemaster::Backend;
 use Zonemaster::Engine::Normalization qw( normalize_name trim_space );
 use Zonemaster::Engine::Profile;
 use Zonemaster::Engine::Recursor;
-use Zonemaster::Backend;
-use Zonemaster::Backend::Config;
-use Zonemaster::Backend::Translator;
-use Zonemaster::Backend::Validator;
-use Zonemaster::Backend::Errors;
-use Zonemaster::Backend::TLD_URL;
+use Zonemaster::Engine;
 
 my $zm_validator = Zonemaster::Backend::Validator->new;
 our %json_schemas;
@@ -46,20 +46,21 @@ sub new {
     my $self = {};
     bless( $self, $type );
 
-    if ( ! $params || ! $params->{config} ) {
-        handle_exception("Missing 'config' parameter");
+    if ( !$params || !$params->{config} ) {
+        handle_exception( "Missing 'config' parameter" );
     }
 
     $self->{config} = $params->{config};
 
     my $dbtype;
     if ( $params->{dbtype} ) {
-        $dbtype = $self->{config}->check_db($params->{dbtype});
-    } else {
+        $dbtype = $self->{config}->check_db( $params->{dbtype} );
+    }
+    else {
         $dbtype = $self->{config}->DB_engine;
     }
 
-    $self->_init_db($dbtype);
+    $self->_init_db( $dbtype );
 
     $self->{_profiles} = Zonemaster::Backend::Config->load_profiles(    #
         $self->{config}->PUBLIC_PROFILES,
@@ -77,15 +78,15 @@ sub _init_db {
         $self->{db} = $dbclass->from_config( $self->{config} );
     };
 
-    if ($@) {
-        handle_exception("Failed to initialize the [$dbtype] database backend module: [$@]");
+    if ( $@ ) {
+        handle_exception( "Failed to initialize the [$dbtype] database backend module: [$@]" );
     }
 }
 
 sub handle_exception {
     my ( $exception ) = @_;
 
-    if ( !$exception->isa('Zonemaster::Backend::Error') ) {
+    if ( !$exception->isa( 'Zonemaster::Backend::Error' ) ) {
         my $reason = $exception;
         $exception = Zonemaster::Backend::Error::Internal->new( reason => $reason );
     }
@@ -93,26 +94,28 @@ sub handle_exception {
     my $log_extra = $exception->as_hash;
     delete $log_extra->{message};
 
-    if ( $exception->isa('Zonemaster::Backend::Error::Internal') ) {
-        $log->error($exception->as_string, $log_extra);
-    } else {
-        $log->info($exception->as_string, $log_extra);
+    if ( $exception->isa( 'Zonemaster::Backend::Error::Internal' ) ) {
+        $log->error( $exception->as_string, $log_extra );
+    }
+    else {
+        $log->info( $exception->as_string, $log_extra );
     }
 
     die $exception->as_hash;
 }
 
 $json_schemas{version_info} = joi->object->strict;
+
 sub version_info {
     my ( $self ) = @_;
 
     my %ver;
     eval {
-        $ver{zonemaster_ldns} = Zonemaster::LDNS->VERSION;
-        $ver{zonemaster_engine} = Zonemaster::Engine->VERSION;
+        $ver{zonemaster_ldns}    = Zonemaster::LDNS->VERSION;
+        $ver{zonemaster_engine}  = Zonemaster::Engine->VERSION;
         $ver{zonemaster_backend} = Zonemaster::Backend->VERSION;
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -121,11 +124,13 @@ sub version_info {
 
 # Experimental
 $json_schemas{system_versions} = $json_schemas{version_info};
+
 sub system_versions {
     return version_info( @_ );
 }
 
 $json_schemas{profile_names} = joi->object->strict;
+
 sub profile_names {
     my ( $self ) = @_;
 
@@ -140,16 +145,16 @@ sub profile_names {
 
 # Experimental
 $json_schemas{conf_profiles} = $json_schemas{profile_names};
+
 sub conf_profiles {
-    my $result = {
-        profiles => profile_names( @_ )
-    };
+    my $result = { profiles => profile_names( @_ ) };
     return $result;
 }
 
 # Return the list of language tags supported by get_test_results(). The tags are
 # derived from the locale tags set in the configuration file.
 $json_schemas{get_language_tags} = joi->object->strict;
+
 sub get_language_tags {
     my ( $self ) = @_;
 
@@ -168,10 +173,9 @@ sub get_language_tags {
 
 # Experimental
 $json_schemas{conf_languages} = $json_schemas{get_language_tags};
+
 sub conf_languages {
-    my $result = {
-        languages => get_language_tags( @_ )
-    };
+    my $result = { languages => get_language_tags( @_ ) };
     return $result;
 }
 
@@ -183,44 +187,46 @@ separate Perl module.
 
 =cut
 
-
 $json_schemas{get_tld_url} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'domain' ],
-    properties => {
+    required             => ['domain'],
+    properties           => {
         domain => $zm_validator->domain_name
     }
 };
+
 sub get_tld_url {
     my ( $self, $params ) = @_;
     my $domain;
-    ( undef, $domain ) = normalize_name( trim_space ( $params->{domain} ) );
+    ( undef, $domain ) = normalize_name( trim_space( $params->{domain} ) );
 
     return Zonemaster::Backend::TLD_URL::process( $self, $domain );
 }
 
-
 $json_schemas{get_host_by_name} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'hostname' ],
-    properties => {
+    required             => ['hostname'],
+    properties           => {
         hostname => $zm_validator->domain_name
     }
 };
+
 sub get_host_by_name {
     my ( $self, $params ) = @_;
     my @adresses;
 
     eval {
-        my $ns_name  = $params->{hostname};
+        my $ns_name = $params->{hostname};
 
-        @adresses = map { {$ns_name => $_->short} } $recursor->get_addresses_for($ns_name);
+        @adresses = map {
+            { $ns_name => $_->short }
+        } $recursor->get_addresses_for( $ns_name );
         @adresses = { $ns_name => '0.0.0.0' } if not @adresses;
 
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -229,46 +235,46 @@ sub get_host_by_name {
 
 # Experimental
 $json_schemas{lookup_address_records} = $json_schemas{get_host_by_name};
+
 sub lookup_address_records {
-    my $result = {
-        address_records => get_host_by_name( @_ )
-    };
+    my $result = { address_records => get_host_by_name( @_ ) };
     return $result;
 }
 
 $json_schemas{get_data_from_parent_zone} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'domain' ],
-    properties => {
-        domain => $zm_validator->domain_name,
+    required             => ['domain'],
+    properties           => {
+        domain   => $zm_validator->domain_name,
         language => $zm_validator->language_tag,
     }
 };
+
 sub get_data_from_parent_zone {
     my ( $self, $params ) = @_;
 
     my $result = eval {
         my %result;
         my $domain = $params->{domain};
-        my ( $_errors, $normalized_domain ) = normalize_name( trim_space ( $domain ) );
+        my ( $_errors, $normalized_domain ) = normalize_name( trim_space( $domain ) );
 
         my @ns_list;
         my @ns_names;
 
         my $zone = Zonemaster::Engine->zone( $normalized_domain );
-        push @ns_list, { ns => $_->name->string, ip => $_->address->short} for @{$zone->glue};
+        push @ns_list, { ns => $_->name->string, ip => $_->address->short } for @{ $zone->glue };
 
         my @ds_list;
 
-        $zone = Zonemaster::Engine->zone($normalized_domain);
+        $zone = Zonemaster::Engine->zone( $normalized_domain );
         my $ds_p = $zone->parent->query_one( $zone->name, 'DS', { dnssec => 1, cd => 1, recurse => 1 } );
-        if ($ds_p) {
+        if ( $ds_p ) {
             my @ds = $ds_p->get_records( 'DS', 'answer' );
 
             foreach my $ds ( @ds ) {
                 next unless $ds->type eq 'DS';
-                push(@ds_list, { keytag => $ds->keytag, algorithm => $ds->algorithm, digtype => $ds->digtype, digest => $ds->hexdigest });
+                push( @ds_list, { keytag => $ds->keytag, algorithm => $ds->algorithm, digtype => $ds->digtype, digest => $ds->hexdigest } );
             }
         }
 
@@ -276,45 +282,47 @@ sub get_data_from_parent_zone {
         $result{ds_list} = \@ds_list;
         return \%result;
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
-    elsif ($result) {
+    elsif ( $result ) {
         return $result;
     }
 }
 
 # Experimental
 $json_schemas{lookup_delegation_data} = $json_schemas{get_data_from_parent_zone};
+
 sub lookup_delegation_data {
     return get_data_from_parent_zone( @_ );
 }
 
 $json_schemas{start_domain_test} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'domain' ],
-    properties => {
-        domain => $zm_validator->domain_name,
-        ipv4 => joi->boolean->compile,
-        ipv6 => joi->boolean->compile,
+    required             => ['domain'],
+    properties           => {
+        domain      => $zm_validator->domain_name,
+        ipv4        => joi->boolean->compile,
+        ipv6        => joi->boolean->compile,
         nameservers => {
-            type => 'array',
+            type  => 'array',
             items => $zm_validator->nameserver
         },
         ds_info => {
-            type => 'array',
+            type  => 'array',
             items => $zm_validator->ds_info
         },
-        profile => $zm_validator->profile_name,
-        client_id => $zm_validator->client_id->compile,
+        profile        => $zm_validator->profile_name,
+        client_id      => $zm_validator->client_id->compile,
         client_version => $zm_validator->client_version->compile,
-        config => joi->string->compile,
-        priority => $zm_validator->priority->compile,
-        queue => $zm_validator->queue->compile,
-        language => $zm_validator->language_tag,
+        config         => joi->string->compile,
+        priority       => $zm_validator->priority->compile,
+        queue          => $zm_validator->queue->compile,
+        language       => $zm_validator->language_tag,
     }
 };
+
 sub start_domain_test {
     my ( $self, $params ) = @_;
 
@@ -330,7 +338,7 @@ sub start_domain_test {
 
         $result = $self->{db}->create_new_test( $params->{domain}, $params, $self->{config}->ZONEMASTER_age_reuse_previous_test );
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -339,16 +347,16 @@ sub start_domain_test {
 
 # Experimental
 $json_schemas{job_create} = $json_schemas{start_domain_test};
+
 sub job_create {
-    my $result = {
-        job_id => start_domain_test( @_ )
-    };
+    my $result = { job_id => start_domain_test( @_ ) };
     return $result;
 }
 
-$json_schemas{test_progress} = joi->object->strict->props(
+$json_schemas{test_progress} = joi->object->strict->props(    #
     test_id => $zm_validator->test_id->required
 );
+
 sub test_progress {
     my ( $self, $params ) = @_;
 
@@ -357,7 +365,7 @@ sub test_progress {
         my $test_id = $params->{test_id};
         $result = $self->{db}->test_progress( $test_id );
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -365,23 +373,23 @@ sub test_progress {
 }
 
 # Experimental
-$json_schemas{job_status} = joi->object->strict->props(
+$json_schemas{job_status} = joi->object->strict->props(    #
     job_id => $zm_validator->test_id->required
 );
+
 sub job_status {
     my ( $self, $params ) = @_;
 
     $params->{test_id} = delete $params->{job_id};
 
-    my $result = {
-        progress => $self->test_progress( $params )
-    };
+    my $result = { progress => $self->test_progress( $params ) };
     return $result;
 }
 
-$json_schemas{get_test_params} = joi->object->strict->props(
+$json_schemas{get_test_params} = joi->object->strict->props(    #
     test_id => $zm_validator->test_id->required
 );
+
 sub get_test_params {
     my ( $self, $params ) = @_;
 
@@ -391,7 +399,7 @@ sub get_test_params {
 
         $result = $self->{db}->get_test_params( $test_id );
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -399,9 +407,10 @@ sub get_test_params {
 }
 
 # Experimental
-$json_schemas{job_params} = joi->object->strict->props(
+$json_schemas{job_params} = joi->object->strict->props(    #
     job_id => $zm_validator->test_id->required
 );
+
 sub job_params {
     my ( $self, $params ) = @_;
 
@@ -411,19 +420,20 @@ sub job_params {
 }
 
 $json_schemas{get_test_results} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'id', 'language' ],
-    properties => {
-        id => $zm_validator->test_id->required->compile,
+    required             => [ 'id', 'language' ],
+    properties           => {
+        id       => $zm_validator->test_id->required->compile,
         language => $zm_validator->language_tag,
     }
 };
+
 sub get_test_results {
     my ( $self, $params ) = @_;
 
     my $result;
-    eval{
+    eval {
 
         my $locale = $self->_get_locale( $params );
 
@@ -435,7 +445,7 @@ sub get_test_results {
             die "Failed to set locale: $locale";
         }
 
-        eval { $translator->data } if $translator; # Provoke lazy loading of translation data
+        eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
 
         my @zm_results;
         my %testcases;
@@ -453,13 +463,13 @@ sub get_test_results {
                 next;
             }
 
-            $res->{module} = $test_res->{module};
+            $res->{module}  = $test_res->{module};
             $res->{message} = $translator->translate_tag( $test_res ) . "\n";
             $res->{message} =~ s/,/, /isg;
             $res->{message} =~ s/;/; /isg;
-            $res->{level} = $test_res->{level};
-            $res->{testcase} = $test_res->{testcase} // 'UNSPECIFIED';
-            $testcases{$res->{testcase}} = $translator->test_case_description($res->{testcase});
+            $res->{level}                  = $test_res->{level};
+            $res->{testcase}               = $test_res->{testcase} // 'UNSPECIFIED';
+            $testcases{ $res->{testcase} } = $translator->test_case_description( $res->{testcase} );
 
             if ( $test_res->{module} eq 'SYSTEM' ) {
                 if ( $res->{message} =~ /policy\.json/ ) {
@@ -489,16 +499,16 @@ sub get_test_results {
             push( @zm_results, $res );
         }
 
-        $result = $test_info;
+        $result                          = $test_info;
         $result->{testcase_descriptions} = \%testcases;
-        $result->{results} = \@zm_results;
+        $result->{results}               = \@zm_results;
 
         $translator->locale( $previous_locale );
 
         $result = $test_info;
         $result->{results} = \@zm_results;
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -507,14 +517,15 @@ sub get_test_results {
 
 # Experimental
 $json_schemas{job_results} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'job_id', 'language' ],
-    properties => {
-        job_id => $zm_validator->test_id->required->compile,
+    required             => [ 'job_id', 'language' ],
+    properties           => {
+        job_id   => $zm_validator->test_id->required->compile,
         language => $zm_validator->language_tag,
     }
 };
+
 sub job_results {
     my ( $self, $params ) = @_;
 
@@ -532,23 +543,24 @@ sub job_results {
 }
 
 $json_schemas{get_test_history} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'frontend_params' ],
-    properties => {
-        offset => joi->integer->min(0)->compile,
-        limit => joi->integer->min(0)->compile,
-        filter => joi->string->regex('^(?:all|delegated|undelegated)$')->compile,
+    required             => ['frontend_params'],
+    properties           => {
+        offset          => joi->integer->min( 0 )->compile,
+        limit           => joi->integer->min( 0 )->compile,
+        filter          => joi->string->regex( '^(?:all|delegated|undelegated)$' )->compile,
         frontend_params => {
-            type => 'object',
+            type                 => 'object',
             additionalProperties => 0,
-            required => [ 'domain' ],
-            properties => {
+            required             => ['domain'],
+            properties           => {
                 domain => $zm_validator->domain_name
             }
         }
     }
 };
+
 sub get_test_history {
     my ( $self, $params ) = @_;
 
@@ -556,15 +568,17 @@ sub get_test_history {
 
     eval {
         $params->{offset} //= 0;
-        $params->{limit} //= 200;
+        $params->{limit}  //= 200;
         $params->{filter} //= "all";
 
         $results = $self->{db}->get_test_history( $params );
-        my @results = map { { %$_, undelegated => $_->{undelegated} ? JSON::PP::true : JSON::PP::false } } @$results;
+        my @results = map {
+            { %$_, undelegated => $_->{undelegated} ? JSON::PP::true : JSON::PP::false }
+        } @$results;
         $results = \@results;
 
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -573,23 +587,24 @@ sub get_test_history {
 
 # Experimental
 $json_schemas{domain_history} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'params' ],
-    properties => {
-        offset => joi->integer->min(0)->compile,
-        limit => joi->integer->min(0)->compile,
-        filter => joi->string->regex('^(?:all|delegated|undelegated)$')->compile,
+    required             => ['params'],
+    properties           => {
+        offset => joi->integer->min( 0 )->compile,
+        limit  => joi->integer->min( 0 )->compile,
+        filter => joi->string->regex( '^(?:all|delegated|undelegated)$' )->compile,
         params => {
-            type => 'object',
+            type                 => 'object',
             additionalProperties => 0,
-            required => [ 'domain' ],
-            properties => {
+            required             => ['domain'],
+            properties           => {
                 domain => $zm_validator->domain_name
             }
         }
     }
 };
+
 sub domain_history {
     my ( $self, $params ) = @_;
 
@@ -600,7 +615,7 @@ sub domain_history {
     return {
         history => [
             map {
-                {
+                {    #
                     job_id         => $_->{id},
                     created_at     => $_->{created_at},
                     overall_result => $_->{overall_result},
@@ -613,8 +628,9 @@ sub domain_history {
 
 $json_schemas{add_api_user} = joi->object->strict->props(
     username => $zm_validator->username->required,
-    api_key => $zm_validator->api_key->required,
+    api_key  => $zm_validator->api_key->required,
 );
+
 sub add_api_user {
     my ( $self, $params, undef, $remote_ip ) = @_;
 
@@ -635,11 +651,11 @@ sub add_api_user {
         else {
             die Zonemaster::Backend::Error::PermissionDenied->new(
                 message => 'Call to "add_api_user" method not permitted from a remote IP',
-                data => { remote_ip => $remote_ip }
+                data    => { remote_ip => $remote_ip }
             );
         }
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -648,50 +664,50 @@ sub add_api_user {
 
 # Experimental
 $json_schemas{user_create} = $json_schemas{add_api_user};
+
 sub user_create {
-    my $result = {
-        success => add_api_user( @_ )
-    };
+    my $result = { success => add_api_user( @_ ) };
     return $result;
 }
 
 $json_schemas{add_batch_job} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'username', 'api_key', 'domains' ],
-    properties => {
+    required             => [ 'username', 'api_key', 'domains' ],
+    properties           => {
         username => $zm_validator->username->required->compile,
-        api_key => $zm_validator->api_key->required->compile,
-        domains => {
-            type => "array",
+        api_key  => $zm_validator->api_key->required->compile,
+        domains  => {
+            type            => "array",
             additionalItems => 0,
-            items => $zm_validator->domain_name,
-            minItems => 1
+            items           => $zm_validator->domain_name,
+            minItems        => 1
         },
         test_params => {
-            type => 'object',
+            type                 => 'object',
             additionalProperties => 0,
-            properties => {
-                ipv4 => joi->boolean->compile,
-                ipv6 => joi->boolean->compile,
+            properties           => {
+                ipv4        => joi->boolean->compile,
+                ipv6        => joi->boolean->compile,
                 nameservers => {
-                    type => 'array',
+                    type  => 'array',
                     items => $zm_validator->nameserver
                 },
                 ds_info => {
-                    type => 'array',
+                    type  => 'array',
                     items => $zm_validator->ds_info
                 },
-                profile => $zm_validator->profile_name,
-                client_id => $zm_validator->client_id->compile,
+                profile        => $zm_validator->profile_name,
+                client_id      => $zm_validator->client_id->compile,
                 client_version => $zm_validator->client_version->compile,
-                config => joi->string->compile,
-                priority => $zm_validator->priority->compile,
-                queue => $zm_validator->queue->compile,
+                config         => joi->string->compile,
+                priority       => $zm_validator->priority->compile,
+                queue          => $zm_validator->queue->compile,
             }
         }
     }
 };
+
 sub add_batch_job {
     my ( $self, $params ) = @_;
 
@@ -707,7 +723,7 @@ sub add_batch_job {
 
         $results = $self->{db}->add_batch_job( $params );
     };
-    if ($@) {
+    if ( $@ ) {
         handle_exception( $@ );
     }
 
@@ -716,73 +732,71 @@ sub add_batch_job {
 
 # Experimental
 $json_schemas{batch_create} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'username', 'api_key', 'domains' ],
-    properties => {
+    required             => [ 'username', 'api_key', 'domains' ],
+    properties           => {
         username => $zm_validator->username->required->compile,
-        api_key => $zm_validator->api_key->required->compile,
-        domains => {
-            type => "array",
+        api_key  => $zm_validator->api_key->required->compile,
+        domains  => {
+            type            => "array",
             additionalItems => 0,
-            items => $zm_validator->domain_name,
-            minItems => 1
+            items           => $zm_validator->domain_name,
+            minItems        => 1
         },
         job_params => {
-            type => 'object',
+            type                 => 'object',
             additionalProperties => 0,
-            properties => {
-                ipv4 => joi->boolean->compile,
-                ipv6 => joi->boolean->compile,
+            properties           => {
+                ipv4        => joi->boolean->compile,
+                ipv6        => joi->boolean->compile,
                 nameservers => {
-                    type => 'array',
+                    type  => 'array',
                     items => $zm_validator->nameserver
                 },
                 ds_info => {
-                    type => 'array',
+                    type  => 'array',
                     items => $zm_validator->ds_info
                 },
-                profile => $zm_validator->profile_name,
-                client_id => $zm_validator->client_id->compile,
+                profile        => $zm_validator->profile_name,
+                client_id      => $zm_validator->client_id->compile,
                 client_version => $zm_validator->client_version->compile,
-                config => joi->string->compile,
-                priority => $zm_validator->priority->compile,
-                queue => $zm_validator->queue->compile,
+                config         => joi->string->compile,
+                priority       => $zm_validator->priority->compile,
+                queue          => $zm_validator->queue->compile,
             }
         }
     }
 };
+
 sub batch_create {
     my ( $self, $params ) = @_;
 
     $params->{test_params} = delete $params->{job_params};
 
-    my $result = {
-        batch_id => $self->add_batch_job( $params )
-    };
+    my $result = { batch_id => $self->add_batch_job( $params ) };
 
     return $result;
 }
 
 $json_schemas{batch_status} = {
-    type => 'object',
+    type                 => 'object',
     additionalProperties => 0,
-    required => [ 'batch_id' ],
-    properties => {
-        batch_id => $zm_validator->batch_id->required,
-        list_waiting_tests => joi->boolean->compile,
-        list_running_tests => joi->boolean->compile,
+    required             => ['batch_id'],
+    properties           => {
+        batch_id            => $zm_validator->batch_id->required,
+        list_waiting_tests  => joi->boolean->compile,
+        list_running_tests  => joi->boolean->compile,
         list_finished_tests => joi->boolean->compile,
     }
 };
+
 sub batch_status {
     my ( $self, $params ) = @_;
 
     my $result;
-    eval {
-        $result = $self->{db}->batch_status($params);
-    };
-    if ($@) {
+    eval { $result = $self->{db}->batch_status( $params ); };
+    if ( $@ ) {
         handle_exception( $@ );
     }
     return $result;
@@ -815,9 +829,10 @@ sub _set_error_message_locale {
     my ( $self, $params ) = @_;
 
     my @error_response = ();
-    my $locale = $self->_get_locale( $params );
+    my $locale         = $self->_get_locale( $params );
 
-    if (not defined $locale or $locale eq "") {
+    if ( not defined $locale or $locale eq "" ) {
+
         # Don't translate message if locale is not defined
         $locale = "C";
     }
@@ -829,27 +844,29 @@ sub _set_error_message_locale {
 
 my $rpc_request = joi->object->props(
     jsonrpc => joi->string->required,
-    method => $zm_validator->jsonrpc_method()->required,
-    id => joi->type([qw(null number string)]));
+    method  => $zm_validator->jsonrpc_method()->required,
+    id      => joi->type( [qw(null number string)] )
+);
+
 sub jsonrpc_validate {
     my ( $self, $jsonrpc_request ) = @_;
 
-    my @error_rpc = $rpc_request->validate($jsonrpc_request);
-    if ((ref($jsonrpc_request) eq 'HASH' && !exists $jsonrpc_request->{id}) || @error_rpc) {
+    my @error_rpc = $rpc_request->validate( $jsonrpc_request );
+    if ( ( ref( $jsonrpc_request ) eq 'HASH' && !exists $jsonrpc_request->{id} ) || @error_rpc ) {
         $self->_set_error_message_locale;
         return {
             jsonrpc => '2.0',
-            id => undef,
-            error => {
-                code => '-32600',
+            id      => undef,
+            error   => {
+                code    => '-32600',
                 message => 'The JSON sent is not a valid request object.',
-                data => "@error_rpc"
+                data    => "@error_rpc"
             }
-        }
+        };
     }
 
-    my $method_schema = $json_schemas{$jsonrpc_request->{method}};
-    if (blessed $method_schema) {
+    my $method_schema = $json_schemas{ $jsonrpc_request->{method} };
+    if ( blessed $method_schema) {
         $method_schema = $method_schema->compile;
     }
 
@@ -860,24 +877,24 @@ sub jsonrpc_validate {
     if ( exists $method_schema->{required} and not exists $jsonrpc_request->{params} ) {
         return {
             jsonrpc => '2.0',
-            id => $jsonrpc_request->{id},
-            error => {
-                code => '-32602',
+            id      => $jsonrpc_request->{id},
+            error   => {
+                code    => '-32602',
                 message => "Missing 'params' object",
             }
         };
     }
     elsif ( exists $jsonrpc_request->{params} ) {
-        my @error_response = $self->validate_params($method_schema, $jsonrpc_request->{params});
+        my @error_response = $self->validate_params( $method_schema, $jsonrpc_request->{params} );
 
         if ( scalar @error_response ) {
             return {
                 jsonrpc => '2.0',
-                id => $jsonrpc_request->{id},
-                error => {
-                    code => '-32602',
-                    message => decode_utf8(__ 'Invalid method parameter(s).'),
-                    data => \@error_response
+                id      => $jsonrpc_request->{id},
+                error   => {
+                    code    => '-32602',
+                    message => decode_utf8( __ 'Invalid method parameter(s).' ),
+                    data    => \@error_response
                 }
             };
         }
@@ -892,40 +909,43 @@ sub validate_params {
 
     push @error_response, $self->_set_error_message_locale( $params );
 
-    if (blessed $method_schema) {
+    if ( blessed $method_schema) {
         $method_schema = $method_schema->compile;
     }
-    my $jv = JSON::Validator::Schema::Draft7->new->coerce('booleans,numbers,strings')->data($method_schema);
-    $jv->formats(Zonemaster::Backend::Validator::formats( $self->{config} ));
+    my $jv = JSON::Validator::Schema::Draft7->new->coerce( 'booleans,numbers,strings' )->data( $method_schema );
+    $jv->formats( Zonemaster::Backend::Validator::formats( $self->{config} ) );
     my @json_validation_error = $jv->validate( $params );
 
     # Customize error message from json validation
     foreach my $err ( @json_validation_error ) {
         my $message = $err->message;
-        my @details = @{$err->details};
+        my @details = @{ $err->details };
 
         # Handle 'required' errors globally so it does not get overwritten
-        if ($details[1] eq 'required') {
+        if ( $details[1] eq 'required' ) {
             $message = N__ 'Missing property';
-        } else {
+        }
+        else {
             my @path = split '/', $err->path, -1;
-            shift @path; # first item is an empty string
+            shift @path;    # first item is an empty string
             my $found = 1;
-            my $data = Mojo::JSON::Pointer->new($method_schema);
+            my $data  = Mojo::JSON::Pointer->new( $method_schema );
 
-            foreach my $p (@path) {
-                if ( $data->contains("/properties/$p") ) {
-                    $data = $data->get("/properties/$p")
-                } elsif ( $p =~ /^\d+$/ and $data->contains("/items") ) {
-                    $data = $data->get("/items")
-                } else {
+            foreach my $p ( @path ) {
+                if ( $data->contains( "/properties/$p" ) ) {
+                    $data = $data->get( "/properties/$p" );
+                }
+                elsif ( $p =~ /^\d+$/ and $data->contains( "/items" ) ) {
+                    $data = $data->get( "/items" );
+                }
+                else {
                     $found = 0;
                     last;
                 }
-                $data = Mojo::JSON::Pointer->new($data);
+                $data = Mojo::JSON::Pointer->new( $data );
             }
 
-            if ($found and exists $data->data->{'x-error-message'}) {
+            if ( $found and exists $data->data->{'x-error-message'} ) {
                 $message = $data->data->{'x-error-message'};
             }
         }
@@ -935,7 +955,9 @@ sub validate_params {
     }
 
     # Translate messages
-    @error_response = map { { %$_,  ( message => decode_utf8 __ $_->{message} ) } } @error_response;
+    @error_response = map {
+        { %$_, ( message => decode_utf8 __ $_->{message} ) }
+    } @error_response;
 
     return @error_response;
 }

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -52,6 +52,8 @@ sub new {
         croak 'Unrecognized arguments: ' . join( ', ', sort keys %args );
     }
 
+    $db->assert_compatible_schema;
+
     my $obj = {
         config    => $config,
         db        => $db,

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -1,10 +1,10 @@
 package Zonemaster::Backend::RPCAPI;
 
-use strict;
-use warnings;
 use 5.14.2;
+use warnings;
 
 # Public Modules
+use Carp        qw( croak );
 use DBI         qw( :utils );
 use Digest::MD5 qw( md5_hex );
 use Encode;
@@ -47,7 +47,7 @@ sub new {
     bless( $self, $type );
 
     if ( !$params || !$params->{config} ) {
-        handle_exception( "Missing 'config' parameter" );
+        croak "Missing 'config' parameter";
     }
 
     $self->{config} = $params->{config};
@@ -79,7 +79,7 @@ sub _init_db {
     };
 
     if ( $@ ) {
-        handle_exception( "Failed to initialize the [$dbtype] database backend module: [$@]" );
+        croak "Failed to initialize the [$dbtype] database backend module: $@";
     }
 }
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -3,7 +3,6 @@ package Zonemaster::Backend::RPCAPI;
 use 5.14.2;
 use warnings;
 
-# Public Modules
 use Carp        qw( croak );
 use DBI         qw( :utils );
 use Digest::MD5 qw( md5_hex );
@@ -19,9 +18,6 @@ use Log::Any           qw( $log );
 use Mojo::JSON::Pointer;
 use POSIX        qw( setlocale );
 use Scalar::Util qw( blessed );
-
-# Zonemaster Modules
-use Zonemaster::Backend::Config;
 use Zonemaster::Backend::Errors;
 use Zonemaster::Backend::TLD_URL;
 use Zonemaster::Backend::Translator;
@@ -41,46 +37,28 @@ sub joi {
 }
 
 sub new {
-    my ( $type, $params ) = @_;
+    my ( $class, %args ) = @_;
 
-    my $self = {};
-    bless( $self, $type );
+    my $config = delete $args{config}
+      or croak "Missing 'config' argument";
 
-    if ( !$params || !$params->{config} ) {
-        croak "Missing 'config' parameter";
+    my $db = delete $args{db}
+      or croak "Missing 'db' argument";
+
+    my $profiles = delete $args{profiles}
+      or croak "Missing 'profiles' argument";
+
+    if ( %args ) {
+        croak 'Unrecognized arguments: ' . join( ', ', sort keys %args );
     }
 
-    $self->{config} = $params->{config};
-
-    my $dbtype;
-    if ( $params->{dbtype} ) {
-        $dbtype = $self->{config}->check_db( $params->{dbtype} );
-    }
-    else {
-        $dbtype = $self->{config}->DB_engine;
-    }
-
-    $self->_init_db( $dbtype );
-
-    $self->{_profiles} = Zonemaster::Backend::Config->load_profiles(    #
-        $self->{config}->PUBLIC_PROFILES,
-        $self->{config}->PRIVATE_PROFILES,
-    );
-
-    return ( $self );
-}
-
-sub _init_db {
-    my ( $self, $dbtype ) = @_;
-
-    eval {
-        my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
-        $self->{db} = $dbclass->from_config( $self->{config} );
+    my $obj = {
+        config    => $config,
+        db        => $db,
+        _profiles => $profiles,
     };
 
-    if ( $@ ) {
-        croak "Failed to initialize the [$dbtype] database backend module: $@";
-    }
+    return bless $obj, $class;
 }
 
 sub handle_exception {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -1,9 +1,9 @@
 package Zonemaster::Backend::TestAgent;
-our $VERSION = '1.1.0';
 
-use strict;
-use warnings;
 use 5.14.2;
+use warnings;
+
+our $VERSION = '1.1.0';
 
 use DBI qw(:utils);
 use JSON::PP;

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -42,6 +42,7 @@ sub new {
 
     my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
     $self->{_db} = $dbclass->from_config( $config );
+    $self->{_db}->assert_compatible_schema;
 
     $self->{_profiles} = Zonemaster::Backend::Config->load_profiles(    #
         $config->PUBLIC_PROFILES,

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -53,7 +53,10 @@ builder {
         my $app = shift;
 
         # Make sure we can connect to the database
-        $config->new_DB();
+        my $dbh = $config->new_DB;
+
+        # Make sure the database has the expected schema version
+        $dbh->assert_compatible_schema;
 
         return $app;
     };

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -39,7 +39,11 @@ $SIG{__WARN__} = sub {
     $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);
 };
 
-my $config = Zonemaster::Backend::Config->load_config();
+my $config   = Zonemaster::Backend::Config->load_config();
+my $profiles = Zonemaster::Backend::Config->load_profiles(    #
+    $config->PUBLIC_PROFILES,
+    $config->PRIVATE_PROFILES,
+);
 
 Zonemaster::Backend::Metrics->setup($config->METRICS_statsd_host, $config->METRICS_statsd_port);
 Zonemaster::Engine::init_engine();
@@ -55,7 +59,11 @@ builder {
     };
 };
 
-my $handler = Zonemaster::Backend::RPCAPI->new( { config => $config } );
+my $handler = Zonemaster::Backend::RPCAPI->new(
+    config   => $config,
+    db       => $config->new_DB,
+    profiles => $profiles,
+);
 
 my $router = router {
 ############## FRONTEND ####################

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -164,7 +164,10 @@ sub preflight_checks {
     Zonemaster::Backend::Metrics->setup($initial_config->METRICS_statsd_host, $initial_config->METRICS_statsd_port);
 
     # Validate the Zonemaster-Engine profile
-    Zonemaster::Backend::TestAgent->new( { config => $initial_config } );
+    Zonemaster::Backend::Config->load_profiles(    #
+        $initial_config->PUBLIC_PROFILES,
+        $initial_config->PRIVATE_PROFILES,
+    );
 
     # Connect to the database
     $initial_config->new_DB();

--- a/share/patch/patch_db_schema_version_1.pl
+++ b/share/patch/patch_db_schema_version_1.pl
@@ -1,0 +1,35 @@
+use 5.14.2;
+use strict;
+use warnings;
+
+use Readonly;
+use Zonemaster::Backend::Config;
+
+Readonly my $EXPECTED_SCHEMA_VERSION => 0;
+
+my $config = Zonemaster::Backend::Config->load_config();
+say "Configured database engine: ", $config->DB_engine;
+
+my $db               = $config->new_DB();
+my $detected_version = $db->get_schema_version();
+say "Expected pre-migration schema version: ", $EXPECTED_SCHEMA_VERSION;
+say "Detected database schema version: ",      $detected_version;
+
+if ( $detected_version ne $EXPECTED_SCHEMA_VERSION ) {
+    say "Schema version requirement not met!";
+    exit 2;
+}
+
+say "Starting database migration";
+
+$db->dbh->do(
+    "CREATE TABLE IF NOT EXISTS schema_version (
+        id INTEGER PRIMARY KEY,
+        version INTEGER NOT NULL,
+        CHECK (id = 1),
+        CHECK (version >= 1)
+    )"
+);
+$db->dbh->do( "INSERT INTO schema_version (id, version) VALUES (1, 1)" );
+
+say "Migration done";

--- a/share/patch/patch_db_schema_version_1.pl
+++ b/share/patch/patch_db_schema_version_1.pl
@@ -5,17 +5,23 @@ use warnings;
 use Readonly;
 use Zonemaster::Backend::Config;
 
-Readonly my $EXPECTED_SCHEMA_VERSION => 0;
+Readonly my $TARGET_SCHEMA_VERSION   => 1;
+Readonly my $EXPECTED_SCHEMA_VERSION => $TARGET_SCHEMA_VERSION - 1;
 
 my $config = Zonemaster::Backend::Config->load_config();
 say "Configured database engine: ", $config->DB_engine;
 
 my $db               = $config->new_DB();
 my $detected_version = $db->get_schema_version();
+say "Target database schema version: ",        $TARGET_SCHEMA_VERSION;
 say "Expected pre-migration schema version: ", $EXPECTED_SCHEMA_VERSION;
 say "Detected database schema version: ",      $detected_version;
 
-if ( $detected_version ne $EXPECTED_SCHEMA_VERSION ) {
+if ( $detected_version eq $TARGET_SCHEMA_VERSION ) {
+    say "Schema already at target version.";
+    exit 0;
+}
+elsif ( $detected_version ne $EXPECTED_SCHEMA_VERSION ) {
     say "Schema version requirement not met!";
     exit 2;
 }
@@ -30,6 +36,6 @@ $db->dbh->do(
         CHECK (version >= 1)
     )"
 );
-$db->dbh->do( "INSERT INTO schema_version (id, version) VALUES (1, 1)" );
+$db->dbh->do( "INSERT INTO schema_version (id, version) VALUES (1, ?)", {}, $TARGET_SCHEMA_VERSION );
 
 say "Migration done";

--- a/t/TestUtil.pm
+++ b/t/TestUtil.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Test::More;
 
+use Carp qw( croak );
 use Zonemaster::Engine;
 use Zonemaster::Backend::Config;
 
@@ -106,27 +107,32 @@ sub init_db {
 }
 
 sub create_rpcapi {
-    my ( $config ) = @_;
+    my ( $config, %opts ) = @_;
 
-    my $rpcapi;
-    eval {
-        $rpcapi = Zonemaster::Backend::RPCAPI->new(
-            {
-                dbtype => $db_backend,
-                config => $config,
-            }
-        );
-    };
-    if ( $@ ) {
-        diag explain( $@ );
-        BAIL_OUT( 'Could not connect to database' );
+    my $dbtype_opt = delete $opts{override_dbtype};
+    if ( %opts ) {
+        croak 'Unrecognized options: ' . join( ', ', sort keys %opts );
     }
 
-    if ( not $rpcapi->isa('Zonemaster::Backend::RPCAPI' ) ) {
+    my $profiles = Zonemaster::Backend::Config->load_profiles(    #
+        $config->PUBLIC_PROFILES,
+        $config->PRIVATE_PROFILES,
+    );
+
+    my $dbtype = $dbtype_opt // $db_backend;
+    my $db     = $config->new_DB( override_dbtype => $dbtype );
+
+    prepare_db( $db );
+
+    my $rpcapi = Zonemaster::Backend::RPCAPI->new(
+        config   => $config,
+        db       => $db,
+        profiles => $profiles,
+    );
+
+    if ( not $rpcapi->isa( 'Zonemaster::Backend::RPCAPI' ) ) {
         BAIL_OUT( 'Not a Zonemaster::Backend::RPCAPI object' );
     }
-
-    prepare_db( $rpcapi->{db} );
 
     return $rpcapi;
 }
@@ -178,10 +184,15 @@ file.
 
 Database tables are dropped and created anew.
 
-=item create_rpcapi($config)
+=item create_rpcapi($config, %opts)
 
 Returns a new Zonemaster::Backend::RPCAPI object using the provided C<$config>
 file.
+
+The C<override_dbtype> option overrides the effective value of C<DB.engine>.
+
+The value of C<DB.engine> in C<$config> is ignored. The effective value is taken from the
+C<override_dbtype> option, C<TARGET> environment variable, or C<SQLite> by default.
 
 Database tables are dropped and created anew.
 

--- a/t/TestUtil.pm
+++ b/t/TestUtil.pm
@@ -75,7 +75,8 @@ sub restore_datafile {
         die q{Stored data file missing} if not -r $datafile;
         Zonemaster::Engine->preload_cache( $datafile );
         Zonemaster::Engine->profile->set( q{no_network}, 1 );
-    } else {
+    }
+    else {
         diag "recording";
     }
 }

--- a/t/db_schema_version.t
+++ b/t/db_schema_version.t
@@ -1,0 +1,121 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Test::NoWarnings qw( had_no_warnings );
+
+use File::ShareDir qw( dist_file );
+use File::Temp     qw( tempdir );
+
+my $t_path;
+
+BEGIN {
+    use File::Spec::Functions qw( rel2abs );
+    use File::Basename        qw( dirname );
+    $t_path = dirname( rel2abs( $0 ) );
+}
+use lib $t_path;
+
+use TestUtil;
+
+use Zonemaster::Backend::Config;
+use Zonemaster::Backend::RPCAPI;
+use Zonemaster::Backend::TestAgent;
+
+my $db_backend = TestUtil::db_backend();
+
+my $tempdir = tempdir( CLEANUP => 1 );
+my $config  = Zonemaster::Backend::Config->parse( <<EOF );
+[DB]
+engine = $db_backend
+
+[MYSQL]
+host     = localhost
+user     = zonemaster_test
+password = zonemaster
+database = zonemaster_test
+
+[POSTGRESQL]
+host     = localhost
+user     = zonemaster_test
+password = zonemaster
+database = zonemaster_test
+
+[SQLITE]
+database_file = $tempdir/zonemaster.sqlite
+
+[ZONEMASTER]
+age_reuse_previous_test = 10
+EOF
+my $profiles = Zonemaster::Backend::Config->load_profiles(    #
+    $config->PUBLIC_PROFILES,
+    $config->PRIVATE_PROFILES,
+);
+
+my $dbclass = Zonemaster::Backend::DB->get_db_class( $db_backend );
+my $db      = $dbclass->from_config( $config );
+
+subtest 'newly created database' => sub {
+    $db->drop_tables();
+    $db->create_schema();
+
+    my $schema_version = $db->get_schema_version;
+    like $schema_version, qr{^[1-9][0-9]*$}, 'should report schema version as an integer';
+
+    lives_ok { $db->assert_compatible_schema } 'should pass compatibility assertion';
+    lives_ok { Zonemaster::Backend::TestAgent->new( { config => $config } ) } 'should be accepted by TestAgent constructor';
+    lives_ok { Zonemaster::Backend::RPCAPI->new( config => $config, db => $config->new_DB, profiles => $profiles ) } 'should be accepted by RPCAPI constructor';
+};
+
+subtest 'database with future schema version' => sub {
+    $db->drop_tables();
+    $db->create_schema();
+    $db->dbh->do( 'UPDATE schema_version SET version = ?', {}, $Zonemaster::Backend::DB::REQUIRED_SCHEMA_VERSION + 1 );
+
+    my $schema_version = $db->get_schema_version;
+    like $schema_version, qr{^[1-9][0-9]*$}, 'should report schema version as an integer';
+
+    dies_ok { $db->assert_compatible_schema } 'should fail compatibility assertion';
+    dies_ok { Zonemaster::Backend::RPCAPI->new( config => $config, db => $config->new_DB, profiles => $profiles ) } 'should be rejected by RPCAPI constructor';
+    dies_ok { Zonemaster::Backend::TestAgent->new( { config => $config } ) } 'should be rejected by TestAgent constructor';
+};
+
+subtest 'database per Backend 11.2.0' => sub {
+    $db->drop_tables();
+    $db->create_schema();
+    $db->dbh->do( 'DROP TABLE schema_version' );
+
+    my $schema_version = $db->get_schema_version;
+    is $schema_version, 0, 'should be inferred as schema version 0';
+
+    dies_ok { $db->assert_compatible_schema } 'should fail compatibility assertion';
+    dies_ok { Zonemaster::Backend::RPCAPI->new( config => $config, db => $config->new_DB, profiles => $profiles ) } 'should be rejected by RPCAPI constructor';
+    dies_ok { Zonemaster::Backend::TestAgent->new( { config => $config } ) } 'should be rejected by TestAgent constructor';
+};
+
+subtest 'database with unrecognized schema version table structure' => sub {
+    $db->drop_tables();
+    $db->create_schema();
+    $db->dbh->do( "DROP TABLE schema_version" );
+    $db->dbh->do( "CREATE TABLE schema_version (foobar INTEGER)" );
+
+    dies_ok { $db->get_schema_version; } 'should die instead of reporting a schema version';
+    dies_ok { $db->assert_compatible_schema } 'should fail compatibility assertion';
+    dies_ok { Zonemaster::Backend::RPCAPI->new( config => $config, db => $config->new_DB, profiles => $profiles ) } 'should be rejected by RPCAPI constructor';
+    dies_ok { Zonemaster::Backend::TestAgent->new( { config => $config } ) } 'should be rejected by TestAgent constructor';
+};
+
+subtest 'database with empty schema version table' => sub {
+    $db->drop_tables();
+    $db->create_schema();
+    $db->dbh->do( "DELETE FROM schema_version" );
+
+    dies_ok { $db->get_schema_version; } 'should die instead of reporting a schema version';
+    dies_ok { $db->assert_compatible_schema } 'should fail compatibility assertion';
+    dies_ok { Zonemaster::Backend::RPCAPI->new( config => $config, db => $config->new_DB, profiles => $profiles ) } 'should be rejected by RPCAPI constructor';
+    dies_ok { Zonemaster::Backend::TestAgent->new( { config => $config } ) } 'should be rejected by TestAgent constructor';
+};
+
+had_no_warnings;
+done_testing;

--- a/t/log.t
+++ b/t/log.t
@@ -1,0 +1,134 @@
+#!perl
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+use Capture::Tiny qw( capture );
+use File::Slurp   qw( slurp );
+use File::Temp    qw( tempdir );
+use JSON::PP      qw( decode_json );
+use Log::Any::Adapter;
+use Test::Fatal qw( exception );
+use Zonemaster::Backend::Log;
+
+sub tmp_log_file {
+    my $dir = tempdir( CLEANUP => 1 );
+    return "$dir/backend.log";
+}
+
+subtest 'render entry in text format' => sub {
+    my $stdout = capture {
+        my $logger = Zonemaster::Backend::Log->new;
+        $logger->structured( 'error', 'unit.test', 'text message', { request_id => 'abc123' }, );
+    };
+
+    like $stdout, qr/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \[\d+\] \[ERROR\] \[unit\.test\] text message/, 'text log entry contains timestamp, pid, level, category and message';
+
+    like $stdout, qr/Extra parameters:/, 'extra parameters are appended';
+    like $stdout, qr/request_id/,        'extra parameter key is present';
+    like $stdout, qr/abc123/,            'extra parameter value is present';
+};
+
+subtest 'render entry in JSON format' => sub {
+    my $stdout = capture {
+        my $logger = Zonemaster::Backend::Log->new( json => 1 );
+        $logger->structured( 'error', 'unit.test', 'json message', { request_id => 'def456' }, );
+    };
+
+    my $entry = decode_json( $stdout );
+
+    is $entry->{level},      'error',        'level is serialized';
+    is $entry->{category},   'unit.test',    'category is serialized';
+    is $entry->{message},    'json message', 'message is serialized';
+    is $entry->{request_id}, 'def456',       'structured data is serialized';
+
+    like $entry->{timestamp}, qr/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/, 'timestamp is serialized as UTC ISO-like string';
+
+    is( $entry->{pid}, $$, 'pid is serialized' );
+};
+
+subtest 'rejects unknown textual log level' => sub {
+    my $error = exception {
+        Zonemaster::Backend::Log->new( log_level => 'not-a-level' );
+    };
+
+    like $error, qr/Unrecognized log level not-a-level/, 'unknown textual log level dies';
+};
+
+subtest 'redirect output to stderr' => sub {
+    my ( $stdout, $stderr ) = capture {
+        my $logger = Zonemaster::Backend::Log->new( stderr => 1 );
+        $logger->structured( 'error', 'unit.test', 'message' );
+    };
+
+    is $stdout, '', 'nothing was written to stdout';
+    like $stderr, qr/\[ERROR\]/, 'entry was written to stderr';
+};
+
+subtest 'redirect output to file' => sub {
+    my $file = tmp_log_file();
+    my ( $stdout, $stderr ) = capture {
+        my $logger = Zonemaster::Backend::Log->new( file => $file );
+        $logger->structured( 'error', 'unit.test', 'message' );
+    };
+    my $content = slurp( $file );
+
+    is $stdout, '', 'nothing was written to stdout';
+    is $stderr, '', 'nothing was written to stderr';
+    like $content, qr/\[ERROR\]/, 'entry was written to file';
+};
+
+subtest 'works as a Log::Any adapter' => sub {
+    my $file = tmp_log_file();
+
+    Log::Any::Adapter->set(
+        { lexically => \my $adapter_scope },
+        '+Zonemaster::Backend::Log',
+        log_level => 'debug',
+        json      => 1,
+    );
+
+    my $log = Log::Any->get_logger( category => 'zonemaster.backend.log.test' );
+
+    ok !$log->is_trace, 'trace is disabled through Log::Any';
+    ok $log->is_debug,  'debug is enabled through Log::Any';
+    ok $log->is_info,   'info is enabled through Log::Any';
+
+    my $stdout = capture {
+        $log->info( 'message through Log::Any', { request_id => 'abc123' }, );
+    };
+
+    my $entry;
+    is
+      exception { $entry = decode_json( $stdout ) },
+      undef,
+      'a single valid JSON value was written';
+
+    is $entry->{level},      'info',                        'Log::Any level reached backend logger';
+    is $entry->{category},   'zonemaster.backend.log.test', 'Log::Any category reached backend logger';
+    is $entry->{message},    'message through Log::Any',    'message reached backend logger';
+    is $entry->{request_id}, 'abc123',                      'structured data reached backend logger';
+    is $entry->{pid},        $$,                            'pid was added by backend logger';
+    ok $entry->{timestamp}, 'timestamp was added by backend logger';
+};
+
+subtest 'Log::Any level detection and filtering use backend log_level' => sub {
+    Log::Any::Adapter->set( { lexically => \my $adapter_scope }, '+Zonemaster::Backend::Log', log_level => 'warning', );
+
+    my $log = Log::Any->get_logger( category => 'zonemaster.backend.log.test' );
+
+    ok !$log->is_info, 'info is disabled through Log::Any';
+    ok $log->is_error, 'error is enabled through Log::Any';
+
+    my $stdout = capture {
+        $log->info( 'filtered message' );
+        $log->warn( 'visible message 1' );
+        $log->error( 'visible message 2' );
+    };
+
+    like $stdout,   qr/\[ERROR\]/,   'error entry was written';
+    like $stdout,   qr/\[WARNING\]/, 'warn entry was written';
+    unlike $stdout, qr/\[INFO\]/,    'info entry was skipped';
+};
+
+done_testing;

--- a/t/parameters_validation.t
+++ b/t/parameters_validation.t
@@ -5,6 +5,16 @@ use utf8;
 use Test::More tests => 4;
 use Test::NoWarnings;
 
+my $t_path;
+
+BEGIN {
+    use File::Spec::Functions qw( rel2abs );
+    use File::Basename        qw( dirname );
+    $t_path = dirname( rel2abs( $0 ) );
+}
+use lib $t_path;
+use TestUtil;
+
 use Cwd;
 use File::Temp qw[tempdir];
 use Zonemaster::Backend::Config;
@@ -26,12 +36,7 @@ database_file = $tempdir/zonemaster.sqlite
 test = $cwd/t/test_profile.json
 EOF
 
-my $rpcapi = Zonemaster::Backend::RPCAPI->new(
-    {
-        dbtype => $config->DB_engine,
-        config => $config,
-    }
-);
+my $rpcapi = TestUtil::create_rpcapi( $config, override_dbtype => $config->DB_engine );
 
 sub test_validation {
     my ( $method_name, $method_schema, $test_cases ) = @_;

--- a/t/parameters_validation.t
+++ b/t/parameters_validation.t
@@ -1,6 +1,5 @@
-use strict;
-use warnings;
 use 5.14.2;
+use warnings;
 use utf8;
 
 use Test::More tests => 4;

--- a/t/rpc_validation.t
+++ b/t/rpc_validation.t
@@ -1,6 +1,5 @@
-use strict;
-use warnings;
 use 5.14.2;
+use warnings;
 use utf8;
 
 use Test::More tests => 30;

--- a/t/rpc_validation.t
+++ b/t/rpc_validation.t
@@ -5,6 +5,16 @@ use utf8;
 use Test::More tests => 30;
 use Test::NoWarnings;
 
+my $t_path;
+
+BEGIN {
+    use File::Spec::Functions qw( rel2abs );
+    use File::Basename        qw( dirname );
+    $t_path = dirname( rel2abs( $0 ) );
+}
+use lib $t_path;
+use TestUtil;
+
 use Cwd;
 use File::Temp qw[tempdir];
 use Zonemaster::Backend::Config;
@@ -30,12 +40,7 @@ database_file = $tempdir/zonemaster.sqlite
 test = $cwd/t/test_profile.json
 EOF
 
-my $rpcapi = Zonemaster::Backend::RPCAPI->new(
-    {
-        dbtype => $config->DB_engine,
-        config => $config,
-    }
-);
+my $rpcapi = TestUtil::create_rpcapi( $config, override_dbtype => $config->DB_engine );
 
 ###
 ### JSONRPC request object construction helper

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -1,6 +1,5 @@
-use strict;
-use warnings;
 use 5.14.2;
+use warnings;
 use utf8;
 
 use Test::More tests => 2;

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -5,6 +5,16 @@ use utf8;
 use Test::More tests => 2;
 use Test::NoWarnings;
 
+my $t_path;
+
+BEGIN {
+    use File::Spec::Functions qw( rel2abs );
+    use File::Basename        qw( dirname );
+    $t_path = dirname( rel2abs( $0 ) );
+}
+use lib $t_path;
+use TestUtil;
+
 use Encode;
 use File::ShareDir qw[dist_file];
 use JSON::PP;
@@ -25,12 +35,7 @@ database_file = $tempdir/zonemaster.sqlite
 locale = en_US fr_FR da_DK fi_FI nb_NO sl_SI sv_SE
 EOF
 
-my $engine = Zonemaster::Backend::RPCAPI->new(
-    {
-        dbtype => $config->DB_engine,
-        config => $config,
-    }
-);
+my $engine = TestUtil::create_rpcapi( $config, override_dbtype => $config->DB_engine );
 
 sub start_domain_validate_params {
     return $engine->validate_params( $Zonemaster::Backend::RPCAPI::json_schemas{start_domain_test}, @_ );


### PR DESCRIPTION
## Purpose

This PR adds an explicit schema version record to the database.

## Context

Fixes #1234.

I rebased this on top of #1247. That commit should not be reviewed as part of this PR, and that PR should be merged before this one.

## Changes

* Database migration is a required step when upgrading Zonemaster Backend. 
* The new database migration script refuses to run unless the database looks to be in the expected pre-migration schema state.
* zm-rpcapi and zm-testagent now refuse to start if the database does not have the correct schema version.

## Commits

1. A separate commit contains some source code formatting of RPCAPI.pm (perltidy + import sorting and formatting)
2. Some drive-by fixes were included in a separate commit
    * Link to public doc site instead of github master branch
    * Report startup errors as strings, not JSON-RPC objects
    * Avoid premature database connection check
    * Put Perl version first (per [recommendation](https://perldoc.perl.org/functions/use#use-VERSION))
    * Clean up redundant strict pragmas
3. One commit refactors allows dependency injection for the RPCAPI module, simplifying testing, especially when the version check is added.
4. The final commit contains the actual schema version feature

## How to test this PR

This procedure tests rejection of old database, debuggability thereof, and migration to new database schema.

 1. Install previous release of Backend
 2. Follow the [upgrade guide](https://doc.zonemaster.net/latest/upgrading/backend.html), halting just before executing the migration script
 3. Run command to start zm-rpcapi and zm-testagent
 4. Verify that both services fail to start again
 5. Verify that both services log contains schema compatibility complaint
    * The error message from zm-rpcapi is shown in the systemd log (on such systems)
    * The error message from zm-testagent is shown in zm-testagent.log
 6. Continue the upgrade guide from where you halted
 7. Perform smoke test
 
Automated tests provide tests for:

 * Initialization of the new database schema
 * Schema version detection semantics
 * Compatibility checks in constructors of critical components (making sure that zm-rpcapi and zm-testagent won't start with an incompatible database)