### PR TITLE
Systemd integration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache \
 
 RUN apk add --no-cache \
 	jq \
+	perl-capture-tiny \
 	perl-class-method-modifiers \
 	perl-config-inifiles \
 	perl-dbd-sqlite \

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -45,6 +45,9 @@ sub init {
     $self->{handle} = IO::Handle->new_from_fd( $fd, "w" ) or croak "Can't fdopen file: $!";
     $self->{handle}->autoflush( 1 );
 
+    $self->{with_timestamp} //= 1;
+    $self->{with_pid}       //= 1;
+
     if ( !exists $self->{formatter} ) {
         if ( $self->{json} ) {
             $self->{formatter} = \&format_json;
@@ -57,10 +60,19 @@ sub init {
 
 sub format_text {
     my ( $self, $log_params ) = @_;
-    my $msg;
-    $msg .= sprintf "%s ", $log_params->{timestamp};
-    delete $log_params->{timestamp};
-    $msg .= sprintf( "[%d] [%s] [%s] %s", delete $log_params->{pid}, uc delete $log_params->{level}, delete $log_params->{category}, delete $log_params->{message} );
+    my $msg = '';
+
+    my $timestamp = delete $log_params->{timestamp};
+    if ( defined $timestamp ) {
+        $msg .= sprintf "%s ", $timestamp;
+    }
+
+    my $pid = delete $log_params->{pid};
+    if ( defined $pid ) {
+        $msg .= sprintf "[%d] ", $pid;
+    }
+
+    $msg .= sprintf( "[%s] [%s] %s", uc delete $log_params->{level}, delete $log_params->{category}, delete $log_params->{message} );
 
     if ( %$log_params ) {
         local $Data::Dumper::Indent = 0;
@@ -90,12 +102,18 @@ sub structured {
     return if $log_level > $self->{log_level};
 
     my %log_params = (
-        timestamp => strftime( "%FT%TZ", gmtime ),
-        level     => $level,
-        category  => $category,
-        message   => $string,
-        pid       => $PID,
+        level    => $level,
+        category => $category,
+        message  => $string,
     );
+
+    if ( $self->{with_timestamp} ) {
+        $log_params{timestamp} = strftime( "%FT%TZ", gmtime );
+    }
+
+    if ( $self->{with_pid} ) {
+        $log_params{pid} = $PID;
+    }
 
     for my $item ( @items ) {
         if ( ref( $item ) eq 'HASH' ) {
@@ -167,6 +185,14 @@ The allowed values are specified at L<Log::Any/LOG-LEVELS>.
 =item json
 
 A boolean. When true, logs are written in JSON format. Default: false.
+
+=item with_timestamp
+
+A boolean. Controls the inclusion of timestamp log entries. Default: true.
+
+=item with_pid
+
+A boolean. Controls the inclusion of PID in log entries. Default: true.
 
 =back
 

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -13,16 +13,15 @@ use Data::Dumper;
 
 use base qw(Log::Any::Adapter::Base);
 
-
-my $default_level = Log::Any::Adapter::Util::numeric_level('info');
+my $default_level = Log::Any::Adapter::Util::numeric_level( 'info' );
 
 sub init {
-    my ($self) = @_;
+    my ( $self ) = @_;
 
     if ( defined $self->{log_level} && $self->{log_level} =~ /\D/ ) {
         $self->{log_level} = lc $self->{log_level};
         my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
-        if ( !defined($numeric_level) ) {
+        if ( !defined( $numeric_level ) ) {
             croak "Error: Unrecognized log level " . $self->{log_level} . "\n";
         }
         $self->{log_level} = $numeric_level;
@@ -31,54 +30,51 @@ sub init {
     $self->{log_level} //= $default_level;
 
     my $fd;
-    if ( !exists $self->{file} || $self->{file} eq '-') {
+    if ( !exists $self->{file} || $self->{file} eq '-' ) {
         if ( $self->{stderr} ) {
-            $fd = fileno(STDERR);
-        } else {
-            $fd = fileno(STDOUT);
+            $fd = fileno( STDERR );
         }
-    } else {
+        else {
+            $fd = fileno( STDOUT );
+        }
+    }
+    else {
         open( $fd, '>>', $self->{file} ) or croak "Can't open log file: $!";
     }
 
     $self->{handle} = IO::Handle->new_from_fd( $fd, "w" ) or croak "Can't fdopen file: $!";
-    $self->{handle}->autoflush(1);
+    $self->{handle}->autoflush( 1 );
 
     if ( !exists $self->{formatter} ) {
         if ( $self->{json} ) {
             $self->{formatter} = \&format_json;
-        } else {
+        }
+        else {
             $self->{formatter} = \&format_text;
         }
     }
 }
 
 sub format_text {
-    my ($self, $log_params) = @_;
+    my ( $self, $log_params ) = @_;
     my $msg;
     $msg .= sprintf "%s ", $log_params->{timestamp};
     delete $log_params->{timestamp};
-    $msg .= sprintf(
-        "[%d] [%s] [%s] %s",
-        delete $log_params->{pid},
-        uc delete $log_params->{level},
-        delete $log_params->{category},
-        delete $log_params->{message}
-    );
+    $msg .= sprintf( "[%d] [%s] [%s] %s", delete $log_params->{pid}, uc delete $log_params->{level}, delete $log_params->{category}, delete $log_params->{message} );
 
     if ( %$log_params ) {
         local $Data::Dumper::Indent = 0;
-        local $Data::Dumper::Terse = 1;
-        my $data = Dumper($log_params);
+        local $Data::Dumper::Terse  = 1;
+        my $data = Dumper( $log_params );
 
         $msg .= " Extra parameters: $data";
     }
 
-    return $msg
+    return $msg;
 }
 
 sub format_json {
-    my ($self, $log_params) = @_;
+    my ( $self, $log_params ) = @_;
 
     my $js = JSON::PP->new;
     $js->canonical( 1 );
@@ -86,41 +82,40 @@ sub format_json {
     return $js->encode( $log_params );
 }
 
-
 sub structured {
-    my ($self, $level, $category, $string, @items) = @_;
+    my ( $self, $level, $category, $string, @items ) = @_;
 
-    my $log_level = Log::Any::Adapter::Util::numeric_level($level);
+    my $log_level = Log::Any::Adapter::Util::numeric_level( $level );
 
     return if $log_level > $self->{log_level};
 
     my %log_params = (
         timestamp => strftime( "%FT%TZ", gmtime ),
-        level => $level,
-        category => $category,
-        message => $string,
-        pid => $PID,
+        level     => $level,
+        category  => $category,
+        message   => $string,
+        pid       => $PID,
     );
 
     for my $item ( @items ) {
-        if (ref($item) eq 'HASH') {
-            for my $key (keys %$item) {
+        if ( ref( $item ) eq 'HASH' ) {
+            for my $key ( keys %$item ) {
                 $log_params{$key} = $item->{$key};
             }
         }
     }
 
-    my $msg = $self->{formatter}->($self, \%log_params);
-    $self->{handle}->print($msg . "\n");
+    my $msg = $self->{formatter}->( $self, \%log_params );
+    $self->{handle}->print( $msg . "\n" );
 }
 
 # From Log::Any::Adapter::File
 foreach my $method ( Log::Any::Adapter::Util::detection_methods() ) {
     no strict 'refs';
-    my $base = substr($method,3);
+    my $base         = substr( $method, 3 );
     my $method_level = Log::Any::Adapter::Util::numeric_level( $base );
     *{$method} = sub {
-        return !!(  $method_level <= $_[0]->{log_level} );
+        return !!( $method_level <= $_[0]->{log_level} );
     };
 }
 

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -120,3 +120,54 @@ foreach my $method ( Log::Any::Adapter::Util::detection_methods() ) {
 }
 
 1;
+
+=head1 NAME
+
+Zonemaster::Backend::Log
+
+=head1 SYNOPSIS
+
+    Log::Any::Adapter->set(
+        '+Zonemaster::Backend::Log',
+        log_level      => 'info',
+        json           => 0,
+        file           => '/path/to/logfile.log',
+        with_pid       => 1,
+        with_timestamp => 1,
+    );
+
+=head1 DESCRIPTION
+
+This is an adapter for Log::Any, tailored towards the needs of Zonemaster
+Backend.
+
+The following attributes are supported.
+
+=over 4
+
+=item file
+
+A string. The location of the log file to use. Default: C<->.
+
+The special value C<-> sends output to stdout or stderr depending on the
+C<stderr> attribute.
+
+=item stderr
+
+A boolean. True means log to stderr. False means log to stdout. Default: false.
+
+Ignored if C<file> is anything other than C<->.
+
+=item log_level
+
+The threshold for emitting log entries. Default: info.
+
+The allowed values are specified at L<Log::Any/LOG-LEVELS>.
+
+=item json
+
+A boolean. When true, logs are written in JSON format. Default: false.
+
+=back
+
+=cut

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -20,7 +20,7 @@ use Try::Tiny;
 BEGIN {
     $ENV{PERL_JSON_BACKEND} = 'JSON::PP';
     undef $ENV{LANGUAGE};
-};
+}
 
 use Zonemaster::Backend::RPCAPI;
 use Zonemaster::Backend::Config;
@@ -31,12 +31,12 @@ local $| = 1;
 Log::Any::Adapter->set(
     '+Zonemaster::Backend::Log',
     log_level => $ENV{ZM_BACKEND_RPCAPI_LOGLEVEL},
-    json => $ENV{ZM_BACKEND_RPCAPI_LOGJSON},
-    stderr => 1
+    json      => $ENV{ZM_BACKEND_RPCAPI_LOGJSON},
+    stderr    => 1,
 );
 
 $SIG{__WARN__} = sub {
-    $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);
+    $log->warning( map s/^\s+|\s+$//gr, map s/\n/ /gr, @_ );
 };
 
 my $config   = Zonemaster::Backend::Config->load_config();
@@ -45,7 +45,7 @@ my $profiles = Zonemaster::Backend::Config->load_profiles(    #
     $config->PRIVATE_PROFILES,
 );
 
-Zonemaster::Backend::Metrics->setup($config->METRICS_statsd_host, $config->METRICS_statsd_port);
+Zonemaster::Backend::Metrics->setup( $config->METRICS_statsd_host, $config->METRICS_statsd_port );
 Zonemaster::Engine::init_engine();
 
 builder {
@@ -72,191 +72,209 @@ my $router = router {
 ############## FRONTEND ####################
     connect "version_info" => {
         handler => $handler,
-        action => "version_info"
+        action  => "version_info"
     };
 
     # Experimental
     connect "system_versions" => {
         handler => $handler,
-        action => "system_versions"
+        action  => "system_versions"
     };
 
     connect "profile_names" => {
         handler => $handler,
-        action => "profile_names"
+        action  => "profile_names"
     };
 
     # Experimental
     connect "conf_profiles" => {
         handler => $handler,
-        action => "conf_profiles"
+        action  => "conf_profiles"
     };
 
     connect "get_language_tags" => {
         handler => $handler,
-        action => "get_language_tags"
+        action  => "get_language_tags"
     };
 
     # Experimental
     connect "conf_languages" => {
         handler => $handler,
-        action => "conf_languages"
+        action  => "conf_languages"
     };
 
     connect "get_host_by_name" => {
         handler => $handler,
-        action => "get_host_by_name"
+        action  => "get_host_by_name"
     };
 
     # Experimental
     connect "lookup_address_records" => {
         handler => $handler,
-        action => "lookup_address_records"
+        action  => "lookup_address_records"
     };
 
     connect "get_data_from_parent_zone" => {
         handler => $handler,
-        action => "get_data_from_parent_zone"
+        action  => "get_data_from_parent_zone"
     };
 
     # Experimental
     connect "lookup_delegation_data" => {
         handler => $handler,
-        action => "lookup_delegation_data"
+        action  => "lookup_delegation_data"
     };
 
     connect "start_domain_test" => {
         handler => $handler,
-        action => "start_domain_test"
+        action  => "start_domain_test"
     };
 
     # Experimental
     connect "job_create" => {
         handler => $handler,
-        action => "job_create"
+        action  => "job_create"
     };
 
     connect "test_progress" => {
         handler => $handler,
-        action => "test_progress"
+        action  => "test_progress"
     };
 
     # Experimental
     connect "job_status" => {
         handler => $handler,
-        action => "job_status"
+        action  => "job_status"
     };
 
     connect "get_test_params" => {
         handler => $handler,
-        action => "get_test_params"
+        action  => "get_test_params"
     };
 
     # Experimental
     connect "job_params" => {
         handler => $handler,
-        action => "job_params"
+        action  => "job_params"
     };
 
     connect "get_test_results" => {
         handler => $handler,
-        action => "get_test_results"
+        action  => "get_test_results"
     };
 
     # Experimental
     connect "job_results" => {
         handler => $handler,
-        action => "job_results"
+        action  => "job_results"
     };
 
     connect "get_test_history" => {
         handler => $handler,
-        action => "get_test_history"
+        action  => "get_test_history"
     };
 
     # Experimental
     connect "domain_history" => {
         handler => $handler,
-        action => "domain_history"
+        action  => "domain_history"
     };
 
     connect "batch_status" => {
         handler => $handler,
-        action => "batch_status"
+        action  => "batch_status"
     };
 
     connect "get_tld_url" => {
         handler => $handler,
-        action => "get_tld_url"
+        action  => "get_tld_url"
     };
 };
 
 if ( $config->RPCAPI_enable_user_create or $config->RPCAPI_enable_add_api_user ) {
-    $log->info('Enabling add_api_user method');
-    $router->connect("add_api_user", {
-        handler => $handler,
-        action => "add_api_user"
-    });
-    $router->connect("user_create", {
-        handler => $handler,
-        action => "user_create"
-    });
+    $log->info( 'Enabling add_api_user method' );
+    $router->connect(
+        "add_api_user",
+        {
+            handler => $handler,
+            action  => "add_api_user"
+        }
+    );
+    $router->connect(
+        "user_create",
+        {
+            handler => $handler,
+            action  => "user_create"
+        }
+    );
 }
 
 if ( $config->RPCAPI_enable_batch_create or $config->RPCAPI_enable_add_batch_job ) {
-    $log->info('Enabling add_batch_job method');
-    $router->connect("add_batch_job", {
-        handler => $handler,
-        action => "add_batch_job"
-    });
-    $router->connect("batch_create", {
-        handler => $handler,
-        action => "batch_create"
-    });
+    $log->info( 'Enabling add_batch_job method' );
+    $router->connect(
+        "add_batch_job",
+        {
+            handler => $handler,
+            action  => "add_batch_job"
+        }
+    );
+    $router->connect(
+        "batch_create",
+        {
+            handler => $handler,
+            action  => "batch_create"
+        }
+    );
 }
 
-my $dispatch = JSON::RPC::Dispatch->new(
-    router => $router,
-);
+my $dispatch = JSON::RPC::Dispatch->new( router => $router, );
 
 my $rpcapi_app = sub {
-    my $env = shift;
-    my $req = Plack::Request->new($env);
-    my $res = {};
-    my $content = {};
+    my $env        = shift;
+    my $req        = Plack::Request->new( $env );
+    my $res        = {};
+    my $content    = {};
     my $json_error = '';
     try {
         my $json = $req->content;
-        $content = decode_json($json);
-    } catch {
-        $json_error = (split /at \//, $_)[0];
+        $content = decode_json( $json );
+    }
+    catch {
+        $json_error = ( split /at \//, $_ )[0];
     };
 
-    if ($json_error eq '') {
-        my $errors = $handler->jsonrpc_validate($content);
-        if ($errors ne '') {
-          $res = Plack::Response->new(200);
-          $res->content_type('application/json');
-          $res->body( encode_json($errors) );
-          $res->finalize;
-        } else {
+    if ( $json_error eq '' ) {
+        my $errors = $handler->jsonrpc_validate( $content );
+        if ( $errors ne '' ) {
+            $res = Plack::Response->new( 200 );
+            $res->content_type( 'application/json' );
+            $res->body( encode_json( $errors ) );
+            $res->finalize;
+        }
+        else {
             local $log->context->{rpc_method} = $content->{method};
-            $res = $dispatch->handle_psgi($env, $env->{REMOTE_ADDR});
-            my $status = Zonemaster::Backend::Metrics->code_to_status(decode_json(@{@$res[2]}[0])->{error}->{code});
-            Zonemaster::Backend::Metrics::increment("zonemaster.rpcapi.requests.$content->{method}.$status");
+            $res = $dispatch->handle_psgi( $env, $env->{REMOTE_ADDR} );
+            my $status = Zonemaster::Backend::Metrics->code_to_status( decode_json( @{ @$res[2] }[0] )->{error}->{code} );
+            Zonemaster::Backend::Metrics::increment( "zonemaster.rpcapi.requests.$content->{method}.$status" );
             $res;
         }
-    } else {
-        $res = Plack::Response->new(200);
-        $res->content_type('application/json');
-        $res->body( encode_json({
+    }
+    else {
+        $res = Plack::Response->new( 200 );
+        $res->content_type( 'application/json' );
+        $res->body(
+            encode_json(
+                {
                     jsonrpc => '2.0',
-                    id => undef,
-                    error => {
-                        code => '-32700',
+                    id      => undef,
+                    error   => {
+                        code    => '-32700',
                         message => 'Invalid JSON was received by the server.',
-                        data => "$json_error"
-                    }}) );
+                        data    => "$json_error"
+                    }
+                }
+            )
+        );
         $res->finalize;
 
     }

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -30,9 +30,11 @@ local $| = 1;
 
 Log::Any::Adapter->set(
     '+Zonemaster::Backend::Log',
-    log_level => $ENV{ZM_BACKEND_RPCAPI_LOGLEVEL},
-    json      => $ENV{ZM_BACKEND_RPCAPI_LOGJSON},
-    stderr    => 1,
+    log_level      => $ENV{ZM_BACKEND_RPCAPI_LOGLEVEL},
+    json           => $ENV{ZM_BACKEND_RPCAPI_LOGJSON},
+    stderr         => 1,
+    with_pid       => !$ENV{ZM_BACKEND_RPCAPI_NO_LOGPID},
+    with_timestamp => !$ENV{ZM_BACKEND_RPCAPI_NO_LOGTIMESTAMP},
 );
 
 $SIG{__WARN__} = sub {

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -43,15 +43,19 @@ my $loglevel;
 my $logjson;
 my $opt_outfile;
 my $opt_help;
+my $opt_logpid       = 1;
+my $opt_logtimestamp = 1;
 GetOptions(
-    'help!'      => \$opt_help,
-    'pidfile=s'  => \$pidfile,
-    'user=s'     => \$user,
-    'group=s'    => \$group,
-    'logfile=s'  => \$logfile,
-    'loglevel=s' => \$loglevel,
-    'logjson!'   => \$logjson,
-    'outfile=s'  => \$opt_outfile,
+    'help!'         => \$opt_help,
+    'pidfile=s'     => \$pidfile,
+    'user=s'        => \$user,
+    'group=s'       => \$group,
+    'logfile=s'     => \$logfile,
+    'loglevel=s'    => \$loglevel,
+    'logjson!'      => \$logjson,
+    'outfile=s'     => \$opt_outfile,
+    'logpid!'       => \$opt_logpid,
+    'logtimestamp!' => \$opt_logtimestamp,
 ) or pod2usage( "Try '$0 --help' for more information." );
 
 pod2usage( -verbose => 1 ) if $opt_help;
@@ -64,9 +68,11 @@ $loglevel = lc $loglevel;
 
 Log::Any::Adapter->set(
     '+Zonemaster::Backend::Log',
-    log_level => $loglevel,
-    json      => $logjson,
-    file      => $logfile,
+    log_level      => $loglevel,
+    json           => $logjson,
+    file           => $logfile,
+    with_pid       => $opt_logpid,
+    with_timestamp => $opt_logtimestamp,
 );
 
 $SIG{__WARN__} = sub {
@@ -262,6 +268,14 @@ The allowed values are specified at L<Log::Any/LOG-LEVELS>.
 =item B<--logjson>
 
 Enable JSON logging when specified.
+
+=item B<--[no-]logtimestamp>
+
+Controls the inclusion of timestamp log entries. Default: enabled.
+
+=item B<--[no-]logpid>
+
+Controls the inclusion of PID in log entries. Default: enabled.
 
 =item B<COMMAND>
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -255,7 +255,7 @@ When FILE is -, the log is written to standard output.
 
 =item B<--loglevel=LEVEL>
 
-The location of the log level to use.
+The threshold for emitting log entries.
 
 The allowed values are specified at L<Log::Any/LOG-LEVELS>.
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -17,7 +17,7 @@ use Pod::Usage;
 use Getopt::Long;
 use POSIX;
 use Time::HiRes qw[time sleep gettimeofday tv_interval];
-use sigtrap qw(die normal-signals);
+use sigtrap     qw(die normal-signals);
 
 ###
 ### Compile-time stuff.
@@ -50,7 +50,7 @@ GetOptions(
     'group=s'    => \$group,
     'logfile=s'  => \$logfile,
     'loglevel=s' => \$loglevel,
-    'logjson!'  => \$logjson,
+    'logjson!'   => \$logjson,
     'outfile=s'  => \$opt_outfile,
 ) or pod2usage( "Try '$0 --help' for more information." );
 
@@ -65,12 +65,12 @@ $loglevel = lc $loglevel;
 Log::Any::Adapter->set(
     '+Zonemaster::Backend::Log',
     log_level => $loglevel,
-    json => $logjson,
-    file => $logfile,
+    json      => $logjson,
+    file      => $logfile,
 );
 
 $SIG{__WARN__} = sub {
-    $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);
+    $log->warning( map s/^\s+|\s+$//gr, map s/\n/ /gr, @_ );
 };
 
 ###
@@ -93,28 +93,25 @@ sub main {
     my $agent = Zonemaster::Backend::TestAgent->new( { config => $self->config } );
 
     while ( !$caught_sigterm ) {
-        my $cleanup_timer = [ gettimeofday ];
+        my $cleanup_timer = [gettimeofday];
 
         $self->pm->reap_finished_children();    # Reaps terminated child processes
         $self->pm->on_wait();                   # Sends SIGKILL to overdue child processes
 
-        Zonemaster::Backend::Metrics::gauge("zonemaster.testagent.maximum_processes", $self->pm->max_procs);
-        Zonemaster::Backend::Metrics::gauge("zonemaster.testagent.running_processes", scalar($self->pm->running_procs));
+        Zonemaster::Backend::Metrics::gauge( "zonemaster.testagent.maximum_processes", $self->pm->max_procs );
+        Zonemaster::Backend::Metrics::gauge( "zonemaster.testagent.running_processes", scalar( $self->pm->running_procs ) );
 
-        Zonemaster::Backend::Metrics::timing("zonemaster.testagent.cleanup_duration_seconds", tv_interval($cleanup_timer) * 1000);
+        Zonemaster::Backend::Metrics::timing( "zonemaster.testagent.cleanup_duration_seconds", tv_interval( $cleanup_timer ) * 1000 );
 
-        my $fetch_test_timer = [ gettimeofday ];
+        my $fetch_test_timer = [gettimeofday];
 
         my ( $test_id, $batch_id );
         eval {
-            $self->db->process_unfinished_tests(
-                $self->config->ZONEMASTER_lock_on_queue,
-                $self->config->ZONEMASTER_max_zonemaster_execution_time,
-            );
+            $self->db->process_unfinished_tests( $self->config->ZONEMASTER_lock_on_queue, $self->config->ZONEMASTER_max_zonemaster_execution_time, );
 
             ( $test_id, $batch_id ) = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
 
-            Zonemaster::Backend::Metrics::timing("zonemaster.testagent.fetchtests_duration_seconds", tv_interval($fetch_test_timer) * 1000);
+            Zonemaster::Backend::Metrics::timing( "zonemaster.testagent.fetchtests_duration_seconds", tv_interval( $fetch_test_timer ) * 1000 );
         };
         if ( $@ ) {
             $log->error( $@ );
@@ -126,22 +123,22 @@ sub main {
             $log->infof( "Test found: %s", $test_id );
             if ( $self->pm->start( $test_id ) == 0 ) {    # Forks off child process
                 $log->infof( "Test starting: %s", $test_id );
-                Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_started");
-                my $start_time = [ gettimeofday ];
+                Zonemaster::Backend::Metrics::increment( "zonemaster.testagent.tests_started" );
+                my $start_time = [gettimeofday];
                 eval { $agent->run( $test_id, $show_progress ) };
                 if ( $@ ) {
                     chomp $@;
-                    Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_died");
+                    Zonemaster::Backend::Metrics::increment( "zonemaster.testagent.tests_died" );
                     $log->errorf( "Test died: %s: %s", $test_id, $@ );
-                    $self->db->process_dead_test( $test_id )
+                    $self->db->process_dead_test( $test_id );
                 }
                 else {
-                    Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_completed");
+                    Zonemaster::Backend::Metrics::increment( "zonemaster.testagent.tests_completed" );
                     $log->infof( "Test completed: %s", $test_id );
                 }
-                Zonemaster::Backend::Metrics::timing("zonemaster.testagent.tests_duration_seconds", tv_interval($start_time) * 1000);
+                Zonemaster::Backend::Metrics::timing( "zonemaster.testagent.tests_duration_seconds", tv_interval( $start_time ) * 1000 );
                 $agent->reset();
-                $self->pm->finish;                   # Terminates child process
+                $self->pm->finish;    # Terminates child process
             }
         }
         else {
@@ -157,11 +154,12 @@ sub main {
 }
 
 sub preflight_checks {
+
     # Make sure we can load the configuration file
-    $log->debug("Starting pre-flight check");
+    $log->debug( "Starting pre-flight check" );
     my $initial_config = Zonemaster::Backend::Config->load_config();
 
-    Zonemaster::Backend::Metrics->setup($initial_config->METRICS_statsd_host, $initial_config->METRICS_statsd_port);
+    Zonemaster::Backend::Metrics->setup( $initial_config->METRICS_statsd_host, $initial_config->METRICS_statsd_port );
 
     # Validate the Zonemaster-Engine profile
     Zonemaster::Backend::Config->load_profiles(    #
@@ -171,20 +169,16 @@ sub preflight_checks {
 
     # Connect to the database
     $initial_config->new_DB();
-    $log->debug("Completed pre-flight check");
+    $log->debug( "Completed pre-flight check" );
 
     return $initial_config;
 }
-
-
 
 my $initial_config;
 
 # Make sure the environment is alright before forking (only on startup)
 if ( grep /^foreground$|^restart$|^start$/, @ARGV ) {
-    eval {
-        $initial_config = preflight_checks();
-    };
+    eval { $initial_config = preflight_checks(); };
     if ( $@ ) {
         $log->critical( "Aborting startup: $@" );
         print STDERR "Aborting startup: $@";
@@ -220,8 +214,8 @@ my $daemon = Daemon::Control->with_plugins( qw( +Zonemaster::Backend::Config::DC
 );
 
 $daemon->init_config( $ENV{PERLBREW_ROOT} . '/etc/bashrc' ) if ( $ENV{PERLBREW_ROOT} );
-$daemon->user($user) if $user;
-$daemon->group($group) if $group;
+$daemon->user( $user )                                      if $user;
+$daemon->group( $group )                                    if $group;
 
 exit $daemon->run;
 

--- a/share/zm-rpcapi.service
+++ b/share/zm-rpcapi.service
@@ -4,10 +4,14 @@ After=network.target mariadb.service postgresql.service
 Wants=mariadb.service postgresql.service
 
 [Service]
-Type=simple
-ExecStart=/usr/local/bin/starman --listen=127.0.0.1:5000 --preload-app --user=zonemaster --group=zonemaster --pid=/run/zonemaster/zm-rpcapi.pid --error-log=/var/log/zonemaster/zm-rpcapi.log --daemonize /usr/local/bin/zonemaster_backend_rpcapi.psgi
+Type=exec
+User=zonemaster
+Group=zonemaster
 KillSignal=SIGQUIT
-PIDFile=/run/zonemaster/zm-rpcapi.pid
+ExecStart=/usr/local/bin/starman \
+  --listen=127.0.0.1:5000 \
+  --preload-app \
+  /usr/local/bin/zonemaster_backend_rpcapi.psgi
 
 [Install]
 WantedBy=multi-user.target

--- a/share/zm-rpcapi.service
+++ b/share/zm-rpcapi.service
@@ -7,6 +7,8 @@ Wants=mariadb.service postgresql.service
 Type=exec
 User=zonemaster
 Group=zonemaster
+Environment=ZM_BACKEND_RPCAPI_NO_LOGPID=1
+Environment=ZM_BACKEND_RPCAPI_NO_LOGTIMESTAMP=1
 KillSignal=SIGQUIT
 ExecStart=/usr/local/bin/starman \
   --listen=127.0.0.1:5000 \

--- a/share/zm-testagent.service
+++ b/share/zm-testagent.service
@@ -4,10 +4,12 @@ After=network.target mariadb.service postgresql.service
 Wants=mariadb.service postgresql.service
 
 [Service]
-Type=simple
-ExecStart=/usr/local/bin/zonemaster_backend_testagent --logfile=/var/log/zonemaster/zm-testagent.log --outfile=/var/log/zonemaster/zm-testagent.out --pidfile=/run/zonemaster/zm-testagent.pid --user=zonemaster --group=zonemaster start
-ExecStop=/usr/local/bin/zonemaster_backend_testagent --logfile=/var/log/zonemaster/zm-testagent.log --outfile=/var/log/zonemaster/zm-testagent.out --pidfile=/run/zonemaster/zm-testagent.pid --user=zonemaster --group=zonemaster stop
-PIDFile=/run/zonemaster/zm-testagent.pid
+Type=exec
+User=zonemaster
+Group=zonemaster
+ExecStart=/usr/local/bin/zonemaster_backend_testagent \
+  --logfile=- \
+  foreground
 
 [Install]
 WantedBy=multi-user.target

--- a/share/zm-testagent.service
+++ b/share/zm-testagent.service
@@ -9,6 +9,8 @@ User=zonemaster
 Group=zonemaster
 ExecStart=/usr/local/bin/zonemaster_backend_testagent \
   --logfile=- \
+  --no-logpid \
+  --no-logtimestamp \
   foreground
 
 [Install]

--- a/t/log.t
+++ b/t/log.t
@@ -30,6 +30,36 @@ subtest 'render entry in text format' => sub {
     like $stdout, qr/abc123/,            'extra parameter value is present';
 };
 
+subtest 'render entry in text format without pid' => sub {
+    my $stdout = capture {
+        my $logger = Zonemaster::Backend::Log->new( with_pid => 0 );
+        $logger->structured( 'error', 'unit.test', 'text message', { request_id => 'abc123' }, );
+    };
+
+    like $stdout, qr{
+        \A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z  # timestamp
+                                                # no pid
+        \s+\[ERROR\]                            # log level
+        \s+\[unit[.]test\]                      # category
+        \s+text[ ]message                       # message
+    }x, 'text log entry contains timestamp, level, category and message, but no pid',;
+};
+
+subtest 'render entry in text format without timestamp' => sub {
+    my $stdout = capture {
+        my $logger = Zonemaster::Backend::Log->new( with_timestamp => 0 );
+        $logger->structured( 'error', 'unit.test', 'text message', { request_id => 'abc123' }, );
+    };
+
+    like $stdout, qr{
+                            # no timestamp
+        \A\[\d+\]           # pid
+        \s+\[ERROR\]        # log level
+        \s+\[unit[.]test\]  # category
+        \s+text[ ]message   # message
+    }x, 'text log entry contains pid, level, category and message, but no timestamp',;
+};
+
 subtest 'render entry in JSON format' => sub {
     my $stdout = capture {
         my $logger = Zonemaster::Backend::Log->new( json => 1 );

--- a/t/log.t
+++ b/t/log.t
@@ -11,18 +11,19 @@ use Log::Any::Adapter;
 use Test::Fatal qw( exception );
 use Zonemaster::Backend::Log;
 
-sub tmp_log_file {
-    my $dir = tempdir( CLEANUP => 1 );
-    return "$dir/backend.log";
-}
-
 subtest 'render entry in text format' => sub {
     my $stdout = capture {
         my $logger = Zonemaster::Backend::Log->new;
         $logger->structured( 'error', 'unit.test', 'text message', { request_id => 'abc123' }, );
     };
 
-    like $stdout, qr/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \[\d+\] \[ERROR\] \[unit\.test\] text message/, 'text log entry contains timestamp, pid, level, category and message';
+    like $stdout, qr{
+        \A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z  # timestamp
+        \s+\[\d+\]                              # pid
+        \s+\[ERROR\]                            # log level
+        \s+\[unit[.]test\]                      # category
+        \s+text[ ]message                       # message
+    }x, 'text log entry contains timestamp, pid, level, category and message',;
 
     like $stdout, qr/Extra parameters:/, 'extra parameters are appended';
     like $stdout, qr/request_id/,        'extra parameter key is present';
@@ -66,7 +67,8 @@ subtest 'redirect output to stderr' => sub {
 };
 
 subtest 'redirect output to file' => sub {
-    my $file = tmp_log_file();
+    my $dir  = tempdir( CLEANUP => 1 );
+    my $file = "$dir/backend.log";
     my ( $stdout, $stderr ) = capture {
         my $logger = Zonemaster::Backend::Log->new( file => $file );
         $logger->structured( 'error', 'unit.test', 'message' );
@@ -79,8 +81,6 @@ subtest 'redirect output to file' => sub {
 };
 
 subtest 'works as a Log::Any adapter' => sub {
-    my $file = tmp_log_file();
-
     Log::Any::Adapter->set(
         { lexically => \my $adapter_scope },
         '+Zonemaster::Backend::Log',


### PR DESCRIPTION
## Purpose

This PR tightens the systemd integration by making systemd responsible for:
1. daemonization,
2. privilege dropping, and
3. log collection.

Benefits are:
1. Improved security by executing less code with elevated privileges.
2. Improved log inspection collecting all logs in journald instead of spreading logs across journald and three files under /var/log/zonemaster.
3. Improved accuracy of `systemctl status`.

## Context

* While testing #1241 I realized that zm-rpcapi and zm-testagent writes its logs to different places (journald vs /var/log/zonemaster).
* With the addition of the configuration file, the installation instruction also needs to be updated, per zonemaster/zonemaster#1489.
* I rebased this on top of zonemaster/zonemaster-backend#1247 (to make CI not break because of zonemaster/zonemaster-engine#1517). That commit should not be reviewed as part of this PR, and that PR should be merged before this one.

## Changes

The systemd unit files are updated for both zm-rpcapi and zm-testagent.

## How to test this PR

Test this on a system with systemd. (N.b., we're currently only using systemd on Rocky.)

The procedure described here shows how to test error inspection at startup time, as well as successful startup.

1. Install the last release of Zonemaster Backend, including database initialization.
2. Run `systemctl stop zm-rpcapi zm-testagent`
3. Run `cpanm --uninstall Zonemaster::Backend`
4. Create a dist file based on this feature branch and install it.
5. Run `systemctl start zm-rpcapi zm-testagent`
6. Run `systemctl status zm-rpcapi zm-testagent` and verify that both services failed to start because of database schema incompatibility
7. Run the database migration script
8. Run `systemctl start zm-rpcapi zm-testagent`
9. Run `systemctl status zm-rpcapi zm-testagent` and verify that both services started successfully