### PR TITLE
Do not reuse DB handles in child processes

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -56,6 +56,12 @@ has 'dbhandle' => (
     required => 1,
 );
 
+has 'dbhandlepid' => (
+    is       => 'rw',
+    isa      => 'Maybe[Int]',
+    required => 0,
+);
+
 =head2 $REQUIRED_SCHEMA_VERSION
 
 A positive integer. The database schema version that this module is compatible with.
@@ -135,7 +141,10 @@ sub get_db_class {
 sub dbh {
     my ( $self ) = @_;
 
-    if ( $self->dbhandle && $self->dbhandle->ping ) {
+    # Do not return the DB handle if it belongs to a different process: we
+    # might have forked and be in the child process. If we are not careful, we
+    # might be messing with someone else's database connection!
+    if ( $self->dbhandle && $self->dbhandle->ping && $self->dbhandlepid && $self->dbhandlepid == $$ ) {
         return $self->dbhandle;
     }
 
@@ -162,6 +171,7 @@ sub dbh {
     );
 
     $self->dbhandle( $dbh );
+    $self->dbhandlepid( $$ );
 
     return $self->dbhandle;
 }


### PR DESCRIPTION
## Purpose

This PR fixes the accidental reuse of the same database connection handle between a parent process and its children, which itself could cause random failures in both the test agent and the RPC API components of Zonemaster-Backend.

The symptom: after some use, a command like `zmtest SOME-DOMAIN` would have its progress stay at 0% forever until the zm-testagent service is restarted. And lines such as the following ones appear in the logs of zm-testagent:

```
[WARNING] [main] DBD::Pg::db do warning:  at /usr/local/share/perl5/Zonemaster/Backend/DB.pm line 380.
[WARNING] [main] Use of uninitialized value $rows_affected in numeric eq (==) at /usr/local/share/perl5/Zonemaster/Backend/DB.pm line 393.
```

Commit d6038049512e57f98408188722475b3e2f9359a8 introduced a pre-flight check  in both the test agent and the RPC API, and this commit is where this specific problem started happening. That pre-flight check involves connecting to the database to check the schema version before starting the daemon proper. For some mysterious reason, if this is done on a Red Hat-based system like RHEL or Rocky Linux (I was unable to reproduce this on Ubuntu and haven’t tested on FreeBSD), it caused database connection handles to be used concurrently by both the parent process and all of its children. The documentation of [DBD::Pg](https://metacpan.org/pod/DBD::Pg) specifically warns against this by saying:

> […] you must tread carefully and ensure that either the parent or the child (but not both!) handles all database calls from that point forwards, so that messages from the Postgres backend are only handled by one of the processes.

The solution is to ensure that database connection handles are always tied to a specific PID. In Zonemaster::Backend::DB, this check is done whenever the dbh() method is called: if the current PID is not the same as the PID that created the database connection, we return a new connection.

## Context

Troubleshooting production instances of Zonemaster.

## Changes

* Make Zonemaster::Backend::DB->dbh() return a fresh database connection if it is holding a handle created by a different PID than the current PID.

## How to test this PR

To reproduce the problem: install Zonemaster-Backend on a Rocky Linux 8 machine following the instructions. Set up a PostgreSQL database.

Then, in a terminal, run `journalctl -xfu zm-testagent`.

Meanwhile, in another terminal, run `for d in a.fr b.fr c.fr d.fr e.fr; do zmb start_domain_test --domain $d; done`.

Watch the logs. When each test starts, there should be a log indicating a new connection to the database. And all tests should complete without ever generating any warnings involving `DBD::Pg::do` (see examples above).